### PR TITLE
Adding new T&Cs for EU (needed for Activo)

### DIFF
--- a/eu.html
+++ b/eu.html
@@ -1,0 +1,1546 @@
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=Generator content="Microsoft Word 15 (filtered)">
+<style>
+<!--
+ /* Font Definitions */
+ @font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+@font-face
+	{font-family:"Avenir W02";
+	panose-1:2 11 5 3 2 2 3 2 2 4;}
+ /* Style Definitions */
+ p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	font-size:12.0pt;
+	font-family:"Calibri",sans-serif;}
+.MsoChpDefault
+	{font-family:"Calibri",sans-serif;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+ ol
+	{margin-bottom:0cm;}
+ul
+	{margin-bottom:0cm;}
+-->
+</style>
+
+</head>
+
+<body lang=EN-GB link=blue vlink="#954F72" style='word-wrap:break-word'>
+
+<div class=WordSection1>
+
+<p class=MsoNormal style='line-height:24.0pt'><b><span style='font-size:21.0pt;
+font-family:"Avenir W02",sans-serif;color:#2E4369'>1. How to read this
+Agreement</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>This Agreement contains 29 sections. You may
+go directly to any section by selecting the appropriate link provided. The
+headings are for reference only. Some capitalised terms have specific
+definitions in section 3. Underlined words in this Agreement contain hyperlinks
+to further information.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>For &quot;send money&quot; transactions,
+this Agreement applies individually to each transaction and is not a Framework
+Contract.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>Where you hold a balance with us (Borderless
+Account), this Agreement applies as a Framework contract to your Borderless
+Account and any payment services involving your balances.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>2.
+Why you should read this Agreement</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.1 What this Agreement covers.&nbsp;</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>These
+are the terms and conditions on which we provide our Services to you.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.2 Why you should read them.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Please
+read this Agreement carefully before you start to use our Services. This
+Agreement (always together with the documents referred to in it) tells you who
+we are, how we will provide the Services to you, how this Agreement may be
+changed or ended, what to do if there is a problem and other important
+information. If you think that there is a mistake in this Agreement or require
+any changes, please&nbsp;</span><a href="https://transferwise.com/contact"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>contact us</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;to
+discuss.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.3 Other additional documents which
+apply to you.&nbsp;</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>This Agreement refers to the following
+additional documents, which also apply to your use of our Services:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a)&nbsp;</span><a
+href="https://transferwise.com/privacy-policy-tw-europe"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Our Privacy Policy</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>,
+which sets out the terms on which we process any personal data we collect about
+you, or that you provide to us. By using our Services, you consent to such
+processing and you promise that all data provided by you is accurate.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(b)&nbsp;</span><a
+href="https://transferwise.com/cookie-policy"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Our Cookie Policy</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>, which sets out information about the
+“cookies” on our Website.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(c)&nbsp;</span><a
+href="https://transferwise.com/gb/legal/acceptable-use-policy-eea"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Our Acceptable Use
+Policy</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>, which sets out the permitted uses and
+prohibited uses of our Services.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(d)&nbsp;</span><a href="https://transferwise.com/help"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Our Frequently Asked
+Questions</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;(&quot;FAQ&quot;) which provides
+answers to common customer questions.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(e) In order to receive some of our
+Services, you may be asked to agree to additional terms and conditions
+(including those referred to in section 29) which we will notify you about at
+the relevant time.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.4 Additional documents.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;For
+clarity, the additional documents and the parts of this Agreement which
+incorporate the additional documents are not Framework Contracts.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.5 Future changes to this Agreement.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;All
+future changes set out in the&nbsp;</span><a
+href="https://transferwise.com/customer-updates"><b><span style='font-family:
+"Avenir W02",sans-serif;color:#00B9FF'>Customer Updates section</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;of
+our Website at the time you sign-up for our Services are incorporated into this
+Agreement. This Agreement may be changed from time to time as set out in
+section 26 of this Agreement.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.6 You accept this Agreement.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;By
+visiting our Website and/or using our Services (including downloading and using
+our App, or via the API, a social media platform or other authorised third
+party), you confirm that you accept and agree to this Agreement (including the
+Customer Updates and the additional documents referred to above). If you do not
+agree, please do not use our Services.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>2.7 Where to get a copy of this
+Agreement.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You can always see the most current
+version of&nbsp;</span><a href="https://transferwise.com/terms-of-use-tw-europe"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>this Agreement</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;on
+our Website. If you want a paper copy of this Agreement, please contact&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>3.
+Glossary</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>In this Agreement:</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>API</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means the
+application programming interface provided by TransferWise.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>App</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means the
+mobile application software, the data supplied with the software and the
+associated media.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Balance</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+any amounts held in your TransferWise Account.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Book II Criminal Code</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+the provisions on cybercrime in Book II of the Belgian Code of Criminal Law.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Book VII CEL</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+the provisions on payment services in Book VII of the Belgian Code of Economic
+Law.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Business Day</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+a day other than a Saturday, Sunday or a public holiday in Belgium when
+financial institutions in Brussels are open for business.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Framework Contract&nbsp;</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>means
+a contract for payment services which governs the future execution of
+individual and successive payment transactions and which may contain the
+obligation and conditions for setting up a payment account as defined in the
+Second Payment Services Directive (2015/2366, &quot;PSD2&quot;) or any
+implementation of PSD2 in any EU or EEA Member State.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Group Company</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+any entity that directly or indirectly controls, is controlled by, or is under
+common control with another entity.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>PIL</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means the
+Belgian Law on Payment Institutions and E-money Institutions of 11 March 2018.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Services</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+all products, services, content, features, technologies or functions offered by
+us and all related websites, applications (including the App), and services
+(including the Website and API).</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Source Currency</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+the currency which you hold and/or fund your payment order with.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Target Currency</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+the currency which your recipient will receive.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>TransferWise Account</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+the account you have opened with us in accordance with the terms of this
+Agreement.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>Website</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+any webpage, including but not limited to www.transferwise.com, where we
+provide the Services to you.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>4.
+TransferWise App and API</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>4.1 App subject to this Agreement and
+the App store Rules.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We license the use of the App to you
+on the basis of this Agreement and subject to any rules and policies applied by
+any appstore provider or operator whose sites are located at&nbsp;</span><a
+href="https://www.apple.com/uk/legal/internet-services/itunes/uk/terms.html"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>App Store</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;and&nbsp;</span><a
+href="https://play.google.com/intl/en_uk/about/play-terms.html"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Google Play</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.
+We do not sell the App to you. We remain the owners of the App at all times.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>4.2 App updates.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;From
+time to time updates to the App may be issued through App Store or Google Play.
+Depending on the update, you may not be able to use our Services via the App
+until you have downloaded the latest version of the App and accepted any new
+terms.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>4.3 Your right to use the App and the
+API.&nbsp;</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>In consideration of you agreeing to abide by
+the terms of this Agreement, we grant you a non-transferable, non-exclusive
+licence to use the App on your device and the API subject to this Agreement. We
+reserve all other rights.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>5.
+Who are we and how to contact us</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>5.1 Our company information.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;TransferWise
+Europe NV/SA is a company incorporated under the law of Belgium with company
+number 0713.629.988 (&quot;TransferWise&quot;, &quot;we&quot;, &quot;us&quot;,
+or &quot;our&quot; as applicable).</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>5.2 Our Belgian Registered office.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Our
+registered office is TransferWise Europe SA/NV, Avenue Louise 54, Room s52,
+1050 Brussels, Belgium.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>5.3 We are authorised by the NBB.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+are authorised as a payment institution by the National Bank of Belgium
+(&quot;NBB&quot;) under the PIL.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>5.4 How to contact us.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+can contact us by email, web chat or telephone. Our contact details are
+provided on the&nbsp;</span><a href="https://transferwise.com/contact"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>&quot;Contact&quot;</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;page
+of our Website.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>6.
+Who can use our Services</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>6.1 You must be 18 years or over.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If
+you are an individual, you must be 18 years or older to use our Services and by
+opening a TransferWise Account you declare that you are 18 years or older. We
+may ask you at any time to show proof of your age.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>6.2 You must have authority to bind your
+business.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;If you are not a consumer, you confirm
+that you have authority to bind any business or entity on whose behalf you use
+our Services, and that business or entity accepts these terms.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>6.3 Your use of the TransferWise Account
+must not violate any applicable laws.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You commit to us that your opening
+and/or using of a TransferWise Account does not violate any laws applicable to
+you. You take responsibility for any consequences of your breach of this
+section.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>7.
+Your TransferWise Account</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>7.1 About your TransferWise Account</span></b></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) Your TransferWise Account allows you to hold, send or
+receive funds.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(b) The funds held on your TransferWise Account does not
+expire other than when your account is closed, see section 19 for more details.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(c) The funds held on your TransferWise Account will not
+earn any interest.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(d) You may hold your funds in any currencies which we
+support from time to time.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(e) You may withdraw money from your TransferWise Account
+at any time, subject to certain conditions, please see section 16 for more
+details.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(f) Certain limits may be placed on your TransferWise
+Account depending on your country of residence, verification checks or other
+legal considerations. Please&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>contact us</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;if you have any questions about these
+limits.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(g) The funds held on your TransferWise Account belongs to
+the person or legal entity which is registered as the TransferWise Account
+holder.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(h) Unless you have our consent in writing,
+you must not allow anyone to operate your TransferWise Account on your behalf.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>7.2</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Your funds in
+the TransferWise Account are treated in accordance with the EU Payment Services
+Directive and the PIL.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>7.3</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Your
+TransferWise Account is a payment account and is not a bank (deposit) account.
+You acknowledge that the Belgian Deposit Guarantee Scheme does not apply to
+your TransferWise Account. However, we follow the requirements under the EU
+Payment Services Directive 2015/2366 (PSD2) and the PIL which are designed to
+ensure the safety of funds held in payment accounts like your TransferWise
+Account. For further information on how we look after your money, please
+visit&nbsp;</span><a href="https://transferwise.com/help"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>8.
+Getting started</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>8.1 Open a TransferWise Account.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;To
+start using our Services, you must open a TransferWise Account and provide your
+details as prompted.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>8.2 Information must be accurate.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;All
+information you provide to us must be complete, accurate and truthful at all
+times. You must update this information whenever it changes. We cannot be
+responsible for any financial loss arising out of your failure to do so. We may
+ask you at any time to confirm the accuracy of your information and/or to
+provide additional supporting documents.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>8.3 Transacting on your own account.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;All
+activities under a TransferWise Account shall be deemed as activities carried
+out by the registered user. You shall only use the Services to transact on your
+own account and not on behalf of any other person or entity.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>8.4 One account per person or entity.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+may only open one TransferWise Account unless we have agreed in writing the
+opening of additional accounts. TransferWise may refuse the creation of
+duplicate accounts for the same user. Where duplicate accounts are detected,
+TransferWise may close or merge these duplicate accounts at its sole
+discretion.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>9.
+Getting to know you</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>9.1</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We are
+required by law to carry out all necessary security and customer due diligence
+checks on you (including any parties involved in your transaction for example
+your recipient) in order to provide any Services to you. You agree to comply
+with any request from us for further information and provide such information
+in a format acceptable to us. In addition, you agree that we may make, directly
+or through any third party, any inquiries we consider necessary to validate the
+information you provided to us, including checking commercial databases or
+credit reports. You authorise us to obtain one or more of your credit reports,
+from time to time, to establish, update, or renew your TransferWise Account
+with us or in the event of a dispute relating to this Agreement and activity
+under your TransferWise Account.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>10.
+Keep your TransferWise Account safe</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>10.1 Keep your TransferWise Account safe</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>(i) What to do.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+must:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) Change your password regularly and ensure that it
+isn’t reused across other online accounts.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(b) Contact&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;if anyone asks for your TransferWise
+password.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(c) Always follow recommended password management
+practice, for example:&nbsp;</span><a
+href="https://support.google.com/accounts/answer/32040?hl=en"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>https://support.google.com/accounts/answer/32040?hl=en</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(d) Set up 2-step authentication where prompted (for
+further instructions please refer to our&nbsp;</span><a
+href="https://transferwise.com/help/article/2738229/other/2-step-login"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>).</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(e) Keep your e-mail account secure. You may
+reset your TransferWise Account password using your email address. Let&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;know immediately if your email address
+becomes compromised.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>(ii) What NOT to do.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+must NOT:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) Disclose your TransferWise Account password or your
+customer reference number (which starts with the letter P followed by a series
+of numbers). Keep them safe.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(b) Let anyone access your TransferWise Account or watch
+you accessing it.</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(c) Use any functionality that allows your login details
+or passwords to be stored by the computer or browser you are using or to be
+cached or otherwise recorded.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(d) Do anything which may in any way avoid
+or compromise the 2-step authentication process.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>10.2 Contact us if you suspect your
+TransferWise Account has been compromised.</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If you suspect
+your TransferWise Account or other security credentials are stolen, lost, used
+without your authorisation or otherwise compromised, you must contact&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;immediately, you are also advised to
+change your password. Any undue delays in notifying us may affect the security
+of your TransferWise Account and also result in you being responsible for
+financial losses.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>10.3 Authorising third parties.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+may authorise third parties to access your TransferWise Account to provide
+their services to you, including authorising them to initiate payments from
+your TransferWise Account. You acknowledge that if you authorise a third party
+to access your TransferWise Account, we may disclose certain information about
+your TransferWise Account to this third party. We are not responsible for any
+such third party’s use of your TransferWise Account or any information in your
+TransferWise Account. Granting permission to a third party does not relieve you
+of your responsibilities under this Agreement, including notifying us if your TransferWise
+Account has been compromised or if a transaction is incorrect or unauthorised.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>11.
+Uploading money into your TransferWise Account</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>11.1 How to upload money into your
+TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;To upload money, you need to log in to
+your TransferWise Account and follow the steps as they appear on screen. We are
+not responsible for the money you have uploaded until we have received them.
+For clarity, in an upload transaction, we are the recipient of funds and not
+the payment services provider.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>11.2 Payin Methods.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+may be presented with one or more methods of upload for example, bank transfer,
+credit cards or debit cards (in this Agreement, we will call these
+methods&nbsp;</span><b><span style='font-family:"Avenir W02",sans-serif;
+color:#2E4369'>“Payin Methods”</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>). The number of Payin Methods made
+available to you will depend on a number of factors including where you live
+and your verification status with us. Payin Methods are not part of our
+Services, they are services provided by third parties for example the card
+provider which issued you with your credit/debit card. We cannot guarantee the
+use of any particular Payin Method and may change or stop offering a Payin
+Method at any time without notice to you.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>11.3 Payment instrument must be in your
+name.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;Any payment instrument (for example, the credit card
+or debit card) you use with your chosen Payin Method must be in your name.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>11.4 Chargebacks on your payment
+instrument.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;If you selected a Payin Method which
+gives you chargeback rights (for example in relation to your credit card, you
+may ask your card provider to reverse a transaction on your card), you promise
+that you will only exercise this chargeback right if:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) we have breached this Agreement; or</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(b) there was an unauthorised use of your
+payment instrument.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>You promise that you will not exercise your
+chargeback right for reasons which we are not responsible, including a dispute
+with your recipient or if there are insufficient funds in your payment
+instrument. If we need to investigate or take any actions in connection with a
+chargeback raised by you, we may charge you for our costs in doing so and may
+deduct such amount from your TransferWise Account.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>11.5 Upload limits on your TransferWise
+Account.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;For legal and security reasons, we impose limits on
+how much you can upload into your TransferWise Account.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>11.6 When we will credit your
+TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We will credit your TransferWise
+Account once we have received your money. For some Payin Methods such as credit
+or debit card, we will credit the money to your TransferWise Account as soon as
+possible subject to our right of reversal. This means if the actual amount you
+intended to upload does not reach us within a reasonable time, we may deduct
+such amount from your TransferWise Account. If you do not have enough money in
+your TransferWise Account for this purpose, we can demand repayment from you
+using other methods.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>12.
+Sending money</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.1 Setting up your payment order</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+must set up your payment order from your TransferWise Account. Your order may
+either be:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) a&nbsp;</span><b><span style='font-family:"Avenir W02",sans-serif;
+color:#2E4369'>&quot;Fixed Source Order&quot;</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;which is a
+payment order where you indicate that you wish to send and convert a fixed
+amount of Source Currency to your recipient who will receive the converted
+amount in the Target Currency; or</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(b) a&nbsp;</span><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>&quot;Fixed Target Order&quot;</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;which
+is a transfer where you indicate that you wish to send and convert a fixed
+amount of Target Currency to your recipient from the Source Currency you pay
+into TransferWise.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>You can only set up a Fixed Target Order for
+certain Source Currencies, you can find a list of these Source Currencies on
+our&nbsp;</span><a
+href="https://transferwise.com/help/article/1652630/creating-a-transfer/specific-amount-transfer"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.2 Information you need to provide to
+set up a payment order.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;To set up a payment order via your
+TransferWise Account, you need to provide certain information to us including
+(a) the full name of your recipient, (b) your recipient’s bank account details
+or their TransferWise Account details and (c) the amount to be transferred.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.3 Payment order limits.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+may place limits on the amount you may send per transfer. For more information
+on the applicable limits, please visit our&nbsp;</span><a
+href="https://transferwise.com/help"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>FAQ</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.4 When is your payment order
+received.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;If your payment order is received by
+us after 5pm on a Business Day or not on a Business Day, your payment order
+will be deemed received on the following Business Day.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.5 What happens after you have
+submitted your payment order.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;Once we have received your payment
+order, we will display it under the Activity section of your TransferWise account.
+Each payment order is given a unique transaction number which you can find
+there. You should quote this number when communicating with us about a
+particular payment order.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.6 You need to provide us with
+sufficient funds before we can process your payment order.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+will only process your payment order if we hold or have received sufficient
+cleared funds in your TransferWise Account. It is your responsibility to fund
+your payment order in a timely manner. We cannot be responsible for the time it
+takes for the money to be sent to us by your bank or payment service provider.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.7 Verification checks may increase
+the time for processing your payment order.</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We carry out
+verification checks, and these checks may increase the time it takes to process
+your payment order. We cannot be responsible for any delays as a result of
+carrying out those checks.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.8 Completion time of your payment
+order.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;The estimated completion time of your payment order
+is notified to you when you complete the setup of your payment order. You may
+also find further information about the completion time in the&nbsp;</span><a
+href="https://transferwise.com/help"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>FAQ</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;section of our Website, please refer
+to the applicable currencies in your payment order.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.9 We will use reasonable efforts to
+ensure funds arrive at your recipient’s account within the notified timeframe.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+will use reasonable efforts to ensure that the funds arrive in the recipient’s
+bank account or payment account within the timelines notified to you or
+otherwise specified in our&nbsp;</span><a href="https://transferwise.com/help"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;section.
+We do not have any control over the time it may take for the recipient’s bank
+or payment provider to credit and make available funds to the recipient.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.10 Refusal of your payment order.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If
+we are unable to complete your payment order, we will let you know and, if
+possible, the reasons for the refusal and an explanation of how to correct any
+factual errors. However, we are not required to notify you if such notification
+would be unlawful.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.11 You may cancel your payment order
+before your funds are converted.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You may cancel your payment order by
+following the instructions set out in our&nbsp;</span><a
+href="https://transferwise.com/help"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>FAQ</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>. You cannot cancel your payment order once
+your funds have been converted into the Target Currency you requested.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.12 You must ensure the information
+you provide to us is correct.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You must make sure that the
+information you provide when setting up a payment order is accurate. If we have
+processed your order in accordance with the information you have provided to us
+it will be considered correctly completed even if you have made a mistake.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.13 What happens if you provide us
+with incorrect information.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;If you provide incorrect information
+with your payment order, we will use reasonable efforts to recover the funds
+for you, and may need to charge you a fee for that.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>12.14 When will I be notified of my next
+scheduled transfer.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;If you have scheduled a transfer in
+advance then we will notify you 24 hours before your upcoming transfer, setting
+out the total fees and the estimated ‘live’ exchange rate for that transfer. By
+scheduling a transfer, you agree to TW sending the funds using the live
+exchange rate at any time on the scheduled date. If you have opted in to
+receiving emails, we will send you a transfer receipt after successfully
+sending your scheduled transfer. For more information on scheduled transfers
+see our&nbsp;</span><a
+href="https://transferwise.com/help/a/2978063/what-are-scheduled-transfers"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Help Centre</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>13.
+Exchange Rates</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>13.1 The applicable exchange rate.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+will let you know the exchange rate:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) when you place your payment order, if it is a
+guaranteed rate payment order; or</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(b) when we have received your payment, if
+it is a non-guaranteed rate payment order.</span></p>
+
+<p class=MsoNormal><b><span style='font-family:"Avenir W02",sans-serif;
+color:#2E4369'>13.2 Exchange rate</span></b></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) Except as specified in section 13.2(b) below, when we
+refer to an exchange rate in this Agreement, it means the mid-market exchange
+rate at the relevant time for the relevant currency pair (for example, GBP to
+EUR, USD to AUD) as provided by our reference rate provider, Reuters. We may
+change our reference rate provider from time to time without notice to you.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(b) For some currencies, we cannot use the
+mid-market exchange rate as we are required to use a different reference rate
+for the exchange rate for your currency pair. For example, for transfers to
+Nigeria (NGN), we are required to use the rate set by the Central Bank of Nigeria.
+For these currencies we will notify you of the reference rate used for the
+exchange rate when you place your payment order.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>13.3 Guaranteed rates.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+offer automatic guaranteed rates on certain payment orders based on the table
+and subject to the conditions&nbsp;</span><a
+href="https://transferwise.com/guaranteed-rate-conditions"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>here</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>,
+which may be changed from time to time.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>14.
+Receiving money</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>14.1 You can receive money into your
+TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You can receive money into your
+TransferWise Account using methods which we support from time to time.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>14.2 The money received is shown in your
+TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;Any money you receive into your
+TransferWise Account will be recorded in the transaction history section of
+your TransferWise Account. You should check the incoming funds in your
+TransferWise Account against your own records regularly and let us know if
+there are any irregularities.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>14.3 The money received may be subject
+to reversal.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You acknowledge that the money
+received in your TransferWise Account (&quot;Received Amount&quot;) may be
+subject to reversal and you agree that we may deduct the Received Amount from
+your TransferWise Account if it was reversed by the person who paid you the
+Received Amount or any relevant payment services provider.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>14.4 Sending money using an email
+address.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;If you send money to a person using an email address
+which is not registered with us, the money will not be credited until the
+intended recipient has claimed the money following the steps we have set out
+for them. Until then, there is no relationship between us and the intended
+recipient and the money continues to belong to you. We will refund the money to
+you if the intended recipient does not claim the money or if they have failed
+our customer checks within a reasonable time period as determined by us.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>15.
+Maintaining your TransferWise Account</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>15.1 Transaction history is displayed on
+your TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;All your transactions (including your
+current Balance, money you have uploaded, received, sent and/or withdrawn) are
+recorded in the transaction history section of your TransferWise Account. You
+may access this information after you log in to your TransferWise Account. We
+have allocated a reference number to each transaction, you should quote this
+reference number when communicating with us about a particular transaction.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>15.2 Check your TransferWise Account
+regularly.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You must check your TransferWise
+Account regularly and carefully and contact us immediately if you don’t
+recognise a transaction or think we have made a payment incorrectly. You must
+tell us about any unauthorised or incorrectly executed transactions
+immediately, but no later than thirteen (13) months from the transaction;
+otherwise you may not be entitled to have any errors corrected.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>15.3 You accept the risks of holding
+balances in multiple currencies.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree and accept all the risks
+associated with maintaining Balances in multiple currencies including any risks
+associated with fluctuations in the relevant exchange rates over time. You agree
+that you will not use our Services for speculative trading.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>15.4 No negative Balance in your
+TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You promise to always have a zero or
+positive Balance in your TransferWise Account. If your TransferWise Account
+goes into a negative Balance as a result of a chargeback, reversal of a
+transaction, deduction of fees or any other action carried by you, you promise
+to repay the negative Balance immediately without any notice from us. We may
+send you reminders or take such other reasonable actions to recover the
+negative Balance from you, for example, we may use a debt collection service or
+take further legal actions. We will charge you for any costs we may incur as a
+result of these additional collection efforts.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>15.5 Taxes.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+are responsible for any taxes which may be applicable to payments you make or
+receive, and it is your responsibility to collect, report and pay the correct
+tax to the appropriate tax authority.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>16.
+Withdrawing from your TransferWise Account</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>16.1 You can request to withdraw your
+money.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;After you log in to your TransferWise Account, you
+may request all or part of your money held in your TransferWise Account to be
+withdrawn. Press &quot;send money&quot; and follow the steps as prompted on
+screen. We will charge you a fee for each withdrawal request where this is
+permissible by law, we will let you know the exact amount when you submit your
+request. You can also find out more information about the fees we charge on
+the&nbsp;</span><a
+href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Pricing page</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>16.2 Payout Methods available to you.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+may be presented with one or more methods of withdrawal (in this Agreement, we
+will call these methods &quot;Payout Methods&quot;). The number of Payout
+Methods made available to you will depend on a number of factors including
+where you live and your verification status with us. We cannot guarantee the
+use of any particular Payout Method and may change or stop offering a Payout
+Method at any time without notice to you, but we will ensure that you will
+always have at least one Payout Method available to you.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>16.3 You must provide correct
+information to us.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;When setting up your withdrawal
+request, you must ensure that the information you provide is correct and complete.
+We will not be responsible for money sent to the wrong recipient as a result of
+incorrect information provided by you. If you have provided wrong information
+to us, you may ask us to assist you in recovering the money, but we cannot
+guarantee that such efforts will be successful.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>16.4 Your withdrawal request is subject
+to limits.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree that your TransferWise
+Account is subject to withdrawal limits. If your withdrawal request exceeds the
+current limit, we may decline your request and require you to provide
+additional documents to us so that we can carry out additional checks before
+allowing the money to be withdrawn.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>17.
+How much will you pay?</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>17.1 You must pay our fees.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+must pay the fees in connection with the use of our Services. We will not
+process your transaction until we have received the fees from you.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>17.2 You can see our fee structure on
+the Pricing page.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We will let you know the exact amount
+payable by you when you set up your order. You can see our fee structure on
+the&nbsp;</span><a
+href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>&quot;Pricing&quot;
+page</span></b></a><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>. For clarity, the fees applicable to you as set out on
+the&nbsp;</span><a
+href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>&quot;Pricing&quot;
+page</span></b></a><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;forms part of this Agreement which may be subject to
+change as set out in section 26.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>17.3 We can make deductions from your
+TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree that we are authorised to
+deduct our fees, any applicable reversal amounts, and/or any amounts you owe us
+from your TransferWise Account. If you don’t have enough money in your
+TransferWise Account to cover these amounts, we may refuse to execute the
+relevant transaction or provide any Services to you.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>18.
+Currency Conversion</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>18.1</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You may
+convert the money held in one currency in your TransferWise Account into other
+currencies we support from time to time. You can only perform a conversion in
+respect of funds that you already hold in your TransferWise Account. A conversion
+fee will apply when we perform a currency conversion, for more information,
+see&nbsp;</span><a href="https://transferwise.com/pricing"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>here</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>19.
+Closing your TransferWise Account</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>19.1 You may close your TransferWise
+Account at any time.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You may end this Agreement and close
+your TransferWise Account at any time by contacting our&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>19.2 You should withdraw your money
+within a reasonable time.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;At the time of closure, if you still
+have money in your TransferWise Account, you must withdraw your money within a
+reasonable period of time by following the steps described in section 16. After
+a reasonable period of time, you will no longer have access to your
+TransferWise Account, but you can still withdraw your money by contacting&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>. You have the right to do this for a period
+of six (6) years from the date your TransferWise Account is closed.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>19.3 You must not close your
+TransferWise Account to avoid an investigation.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+must not close your TransferWise Account to avoid an investigation. If you
+attempt to close your TransferWise Account during an investigation, we may hold
+your money until the investigation is fully completed in order to protect our
+or a third party’s interest.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>19.4 You are responsible for your
+TransferWise Account after closure.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree that you will continue to be
+responsible for all obligations related to your TransferWise Account even after
+it is closed.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>20.
+Intellectual property rights</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>20.1</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;While you are
+using our Services, you may use the TransferWise Materials only for your
+personal use and solely as necessary in relation to those Services.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>20.2</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;&quot;TransferWise
+Materials&quot; include any software (including without limitation the App, the
+API, developer tools, sample source code, and code libraries), data, materials,
+content and printed and electronic documentation (including any specifications
+and integration guides) developed and provided by us or our affiliates to you, or
+available for download from our Website. You may not, and may not attempt to,
+directly or indirectly:</span></p>
+
+<ol start=1 type=a>
+ <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>transfer, sublicense, loan, sell, assign, lease,
+     rent, distribute or grant rights in the Services or the TransferWise
+     Materials to any person or entity;</span></li>
+ <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>remove, obscure, or alter any notice of any of our
+     trade marks, or other &quot;intellectual property&quot; appearing on or
+     contained within the Services or on any TransferWise Materials;</span></li>
+ <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>modify, copy, tamper with or otherwise create
+     derivative works of any software included in the TransferWise Materials;
+     or</span></li>
+ <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>reverse engineer, disassemble, or decompile the
+     TransferWise Materials or the Services or apply any other process or
+     procedure to derive the source code of any software included in the
+     TransferWise Materials or as part of the Services.</span></li>
+</ol>
+
+<p class=MsoNormal style='line-height:24.0pt'><b><span style='font-size:21.0pt;
+font-family:"Avenir W02",sans-serif;color:#2E4369'>21. Our responsibility for
+loss or damage</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.1 We are responsible to you for
+foreseeable loss and damage caused by us.</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If we do not
+reasonably meet our commitments to you, we are responsible for loss or damage
+you suffer that is a foreseeable result of our breaking this contract or our
+failing to use reasonable care and skill. We are not responsible for any loss
+or damage that is not foreseeable. Loss or damage is foreseeable if either it
+is obvious that it will happen or if, at the time the contract was made, both
+we and you knew it might happen, for example, if you discussed it with us
+during your account sign up process.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.2 We do not exclude or limit in any
+way our liability to you where it would be unlawful to do so.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;This
+includes liability for death or personal injury caused by our negligence or the
+negligence of our employees, agents or subcontractors; for fraud or fraudulent
+misrepresentation.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.3 We are not liable for business
+losses.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;If you use our Services for any commercial or
+business purpose we will have no liability to you for any loss of profit, loss
+of business, business interruption, or loss of business opportunity.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.4 We are not liable for technological
+attacks.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>&nbsp;We will not be liable for any loss or damage caused
+by a virus, or other technological attacks or harmful material that may infect
+your computer equipment, computer programmes, data or other proprietary
+material related to your use of our Services.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.5 We have no control over websites
+linked to and from our Website.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We assume no responsibility for their
+content or any loss or damage that may arise from your use of them.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.6 Our liability to you for
+unauthorised payments or our mistake.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;In case of an unauthorised payment or
+mistake due to our error, we shall at your request immediately refund the
+payment amount including all fees deducted by us. This shall not apply:</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(a) where your TransferWise Account, or its
+personalised security features, are lost, stolen or misappropriated. You will
+be liable for the first 50 EUR of any unauthorised payments if we believe you
+should have been aware of the loss, theft or unauthorised use. We will not hold
+you liable for the first 50 EUR if the unauthorised payment was caused either
+by our acts or omissions, or those of a third party expressly carrying out
+activities on our behalf. Your liability for the first 50 EUR also does not
+apply to any unauthorised transactions made after you have notified us that
+your TransferWise Account may have been compromised (using the details we’ve
+given you);</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(b) if you have acted fraudulently, in which
+case we will not refund you in any circumstances;</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(c) if you do not quickly notify us of
+security issues on your TransferWise Account (e.g. loss of your password), you
+remain liable for losses incurred up to your notification to us;</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(d) if the payment transaction was
+unauthorised but you have with intent or gross negligence compromised the
+security of your TransferWise Account or failed to comply with your obligations
+to use your TransferWise Account in the manner set out in this Agreement. In
+such a case you shall be solely liable for all losses; or</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(e) if you don’t let us know about the
+unauthorised or incorrectly completed transaction within thirteen (13) months
+from the date of the payment transaction.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.7 You are responsible for checking
+your TransferWise Account regularly.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We rely on you to regularly check the
+transactions history of your TransferWise Account and to contact&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
+color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;immediately in case you have any
+questions or concerns.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.8 We are not liable for things which
+are outside of our control.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We (and our affiliates) cannot be
+liable for our inability to deliver or delay as a result of things which are outside
+our control.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.9 You are liable for breaking this
+Agreement or applicable laws.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;In the unlikely event of loss or
+claims or costs and expenses arising out of your breach of this Agreement, any
+applicable law or regulation and/or your use of our Services, you agree to
+compensate us and our affiliates and hold us harmless. This provision will
+continue after our relationship ends.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>21.10 What happens if you owe us money.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;In
+the event you are liable for any amounts owed to us, we may immediately remove
+such amounts from your Balance (if available). If there are insufficient funds
+in your Balance to cover your liability, we reserve the right to collect your
+debt to us by using any payments received in your TransferWise Account and
+otherwise you agree to reimburse us through other means. We may also recover
+amounts you owe us through legal means, including, without limitation, through
+the use of a debt collection agency.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>22.
+Accessing our Services</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>22.1</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We will try to
+make sure our Services are available to you when you need them. However, we do
+not guarantee that our Services will always be available or be uninterrupted.
+We may suspend, withdraw, discontinue or change all or any part of our Services
+without notice. We will not be liable to you if for any reason our Services are
+unavailable at any time. You are responsible for making all arrangements
+necessary for you to have access to our Services. If you have granted
+permission to a third party to access your account, we may refuse access to
+that third party if we are concerned about unauthorised or fraudulent access by
+that third party. We will give you notice if we do this, either before or
+immediately after we refuse access, unless notifying you would be unlawful or
+compromise our reasonable security measures.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>23.
+Information security</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>23.1</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You are
+responsible for configuring your information technology, computer programmes
+and platform in order to access our Services. You should use your own virus
+protection software. We take security very seriously at TransferWise and we
+work hard, using state-of-the-art security measures, to make sure that your
+information remains secure. Our Services are a safe and convenient way to send
+money to friends and family and to other people that you trust. However, we do
+advise you to consider very carefully before sending money to anyone that you
+do not know well.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>23.2 You must not misuse our Services.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+must not misuse our Services by introducing viruses, trojans, worms, logic
+bombs or other materials which are malicious or technologically harmful. You
+must not attempt to gain unauthorised access to our Website, our servers,
+computers or databases. You must not attack our Website with any type of denial
+of service attack. By breaching this provision, you would commit a criminal
+offence under Book II Criminal Code. We will report any such breach to the
+relevant law enforcement authorities and we will co-operate with those
+authorities by disclosing your identity to them. In the event of such a breach,
+your right to use our Website and/or our Services will cease immediately. If
+you are aware of anyone or any entity that is using the Services
+inappropriately, please contact us. Similarly, if you receive any emails,
+purporting to be from TransferWise, which you suspect may be phishing emails,
+please forward the email to our Customer Service.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>24.
+Linking to our site</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>24.1 You may link to our Website
+provided you follow certain rules.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You may link to our Website, provided:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) you do so in a way that is fair and legal and does not
+damage our reputation or take advantage of it;</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(b) you do not suggest any form of association, approval
+or endorsement on our part where none exists;</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(c) you do not frame our Website on any other site; and</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(d) the website complies with our&nbsp;</span><a
+href="https://transferwise.com/gb/legal/acceptable-use-policy-eea"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Acceptable Use Policy</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>We reserve the right to withdraw linking
+permission without notice.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>25.
+When we can end this Agreement or suspend our Services</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>25.1 We may end this Agreement by giving
+you two (2) months’ notice.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We may end this Agreement and close
+your TransferWise Account or any service associated with it by giving you two
+(2) months’ prior notice.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>25.2 We may suspend or close your
+TransferWise Account without notice in certain circumstances.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+may at any time suspend or close your TransferWise Account and/or end this
+Agreement without notice if:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) you breach any provision of this Agreement or
+documents referred to in this Agreement;</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(b) we are requested or directed to do so by any competent
+court of law, government authority, public agency, or law enforcement agency;</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(c) we have serious reasons to believe you are in breach
+of any applicable law or regulation; or</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(d) we have serious reasons to believe you
+are involved in any fraudulent activity, money laundering, terrorism financing
+or other criminal or illegal activity.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>25.3 We may suspend your TransferWise
+Account for security reasons.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We may suspend your TransferWise
+Account or restrict its functionality if we have reasonable concerns about:</span></p>
+
+<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
+letter-spacing:.2pt'>(a) the security of your TransferWise Account; or</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>(b) suspected unauthorised or fraudulent use
+of your TransferWise Account.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>25.4 We will give you notice of
+suspension where possible.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;We will give you notice of any
+suspension or restriction and the reasons for such suspension or restriction as
+soon as we can, either before the suspension or restriction is put in place, or
+immediately after, unless notifying you would be unlawful or compromise our
+reasonable security measures. We will lift the suspension and/or the
+restriction as soon as practicable after the reasons for the suspension and/or
+restriction have ceased to exist.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>25.5 You cannot use the App if this
+Agreement ends.&nbsp;</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>On termination for any reason all rights
+granted to you in connection with the App shall cease, you must immediately
+delete or remove the App from your devices.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>26.
+Our right to make changes</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>26.1 We may change this Agreement by
+giving you at least two (2) months’ prior written notice.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If
+we do this, you can terminate this Agreement immediately and free of charge at
+any time before the proposed date of the entry into force of the proposed
+changes, by providing written notice to us. If we do not hear from you during
+the notice period, you will be considered as having accepted the proposed
+changes and they will apply to you from the effective date specified on the
+notice.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>26.2 In some instances, we may change
+this Agreement immediately.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;Despite section 26.1, changes to this
+Agreement which are (1) more favourable to you; (2) required by law; or (3)
+related to the addition of a new service, extra functionality to the existing
+Services; or (4) changes which neither reduce your rights nor increase your
+responsibilities, will come into effect immediately if they are stated in the
+change notice. Changes to exchange rates shall come into effect immediately
+without notice and you shall not have the right to object to such a change.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>27.
+How we may contact you</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>27.1 We usually contact you via email.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;For
+this purpose, you must at all times maintain at least one valid email address
+in your TransferWise Account profile. You should check for incoming messages
+regularly and frequently, these emails may contain links to further
+communication on our Website. If you don’t maintain or check your email and
+other methods of communications, you will miss emails about your transactions
+and our Services. We cannot be liable for any consequence or loss if you don’t
+do this. If we have reasonable concerns either about the security of your
+TransferWise Account, or any suspected or actual fraudulent use of your
+TransferWise Account, we will contact you via telephone, email, or both (unless
+contacting you would be unlawful or compromise our reasonable security
+measures).</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>27.2 Other ways we may contact you.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;In
+addition to communicating via email, we may contact you via letter or telephone
+where appropriate. If you use any mobile services, we may also communicate with
+you via SMS. Any communications or notices sent by:</span></p>
+
+<ol start=1 type=a>
+ <li class=MsoNormal style='color:#5D7079'><b><span style='font-family:"Avenir W02",sans-serif;
+     color:#2E4369'>Email</span></b><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>&nbsp;will be deemed received by you on the same day
+     if it is received in your email inbox before 5pm on a Business Day. If it
+     is received in your email inbox after 5pm on a Business Day or at any
+     other time, it will be deemed received on the next Business Day.</span></li>
+ <li class=MsoNormal style='color:#5D7079'><b><span style='font-family:"Avenir W02",sans-serif;
+     color:#2E4369'>Post</span></b><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>&nbsp;will be deemed received three (3) days from the
+     date of posting for Belgian post or within five (5) days of posting for
+     international post.</span></li>
+ <li class=MsoNormal style='color:#5D7079'><b><span style='font-family:"Avenir W02",sans-serif;
+     color:#2E4369'>SMS</span></b><span style='font-family:"Avenir W02",sans-serif;
+     letter-spacing:.2pt'>&nbsp;will be deemed received the same day.</span></li>
+</ol>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>27.3</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Where
+legislation requires us to provide information to you on a durable medium, we will
+either send you an email (with or without attachment) or send you a
+notification pointing you to information on our Website in a way that enables
+you to retain the information in print format or other format that can be
+retained by you permanently for future reference. Do keep copies of all
+communications we send or make available to you.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>27.4</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If you need a
+copy of the current Agreement or any other relevant document, please
+contact&nbsp;</span><a href="https://transferwise.com/contact"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Customer Support</span></b></a><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>27.5 This Agreement is made in the
+English language.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;Documents or communications in any
+other languages are for your convenience and only the English language version
+of them are official.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>28.
+Complaints</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>28.1</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If you have
+any complaints about us or our Services, you may contact us following our&nbsp;</span><a
+href="https://transferwise.com/help-beta/article/2235393/customer-complaints-procedure"><b><span
+style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>customer complaint
+procedure</span></b></a><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>.</span></p>
+
+<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
+style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>29.
+Other important terms</span></b></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>29.1 Nobody else has any rights under
+this Agreement.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;This Agreement is between you and us.
+No other person shall have any rights to enforce any of its terms. Neither of
+us will need to get the agreement of any other person in order to end or make
+any changes to this Agreement.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>29.2 We may transfer this Agreement to
+someone else.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;You may not transfer, assign,
+mortgage, charge, subcontract, declare a trust over or deal in any other manner
+with any or all of your rights and obligations under this Agreement (including
+the TransferWise Account) without our prior written consent. We reserve the
+right to transfer, assign or novate this Agreement (including the TransferWise
+Account) or any right or obligation under this Agreement at any time without
+your consent and if permissible by law. This does not affect your rights to close
+your TransferWise Account under section 19.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>29.3 If a court finds part of this
+Agreement illegal, the rest will continue in force.</span></b><span
+style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Each
+of the paragraphs of this Agreement operates separately. If any court or
+relevant authority decides that any of them are unlawful, the remaining
+paragraphs will remain in full force and effect.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>29.4 Even if we delay in enforcing this
+Agreement, we can still enforce it later.</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If we delay in
+asking you to do certain things or in taking action, it will not prevent us
+taking steps against you at a later date.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>29.5 This Agreement supersedes any other
+previous agreements.</span></b><span style='font-family:"Avenir W02",sans-serif;
+color:#5D7079;letter-spacing:.2pt'>&nbsp;This Agreement supersedes and
+extinguishes all previous agreements between you and TransferWise, whether
+written or oral, relating to its subject matter.</span></p>
+
+<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
+"Avenir W02",sans-serif;color:#2E4369'>29.6 Which laws apply to this Agreement
+and where you may bring legal proceedings.</span></b><span style='font-family:
+"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;This Agreement
+is governed by Belgian law. Any dispute between you and us in connection with
+your TransferWise Account and/or this Agreement may be brought in the courts of
+Brussels, Belgium.</span></p>
+
+<p class=MsoNormal>&nbsp;</p>
+
+</div>
+
+</body>
+
+</html>

--- a/eu.html
+++ b/eu.html
@@ -1,458 +1,289 @@
-<html>
+<div>
+<a name="customer-agreement"><h1>TransferWise Customer Agreement</h1></a>
 
-<head>
-<meta http-equiv=Content-Type content="text/html; charset=utf-8">
-<meta name=Generator content="Microsoft Word 15 (filtered)">
-<style>
-<!--
- /* Font Definitions */
- @font-face
-	{font-family:"Cambria Math";
-	panose-1:2 4 5 3 5 4 6 3 2 4;}
-@font-face
-	{font-family:Calibri;
-	panose-1:2 15 5 2 2 2 4 3 2 4;}
-@font-face
-	{font-family:"Avenir W02";
-	panose-1:2 11 5 3 2 2 3 2 2 4;}
- /* Style Definitions */
- p.MsoNormal, li.MsoNormal, div.MsoNormal
-	{margin:0cm;
-	font-size:12.0pt;
-	font-family:"Calibri",sans-serif;}
-.MsoChpDefault
-	{font-family:"Calibri",sans-serif;}
-@page WordSection1
-	{size:612.0pt 792.0pt;
-	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
-div.WordSection1
-	{page:WordSection1;}
- /* List Definitions */
- ol
-	{margin-bottom:0cm;}
-ul
-	{margin-bottom:0cm;}
--->
-</style>
-
-</head>
-
-<body lang=EN-GB link=blue vlink="#954F72" style='word-wrap:break-word'>
-
-<div class=WordSection1>
-
-<p class=MsoNormal style='line-height:24.0pt'><b><span style='font-size:21.0pt;
-font-family:"Avenir W02",sans-serif;color:#2E4369'>1. How to read this
+<p ><b><span >1. How to read this
 Agreement</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>This Agreement contains 29 sections. You may
+<p ><span >This Agreement contains 29 sections. You may
 go directly to any section by selecting the appropriate link provided. The
 headings are for reference only. Some capitalised terms have specific
 definitions in section 3. Underlined words in this Agreement contain hyperlinks
 to further information.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>For &quot;send money&quot; transactions,
+<p ><span >For &quot;send money&quot; transactions,
 this Agreement applies individually to each transaction and is not a Framework
 Contract.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>Where you hold a balance with us (Borderless
+<p ><span >Where you hold a balance with us (Borderless
 Account), this Agreement applies as a Framework contract to your Borderless
 Account and any payment services involving your balances.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>2.
+<p ><b><span>2.
 Why you should read this Agreement</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.1 What this Agreement covers.&nbsp;</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>These
+<p ><b><span >2.1 What this Agreement covers.&nbsp;</span></b><span>These
 are the terms and conditions on which we provide our Services to you.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.2 Why you should read them.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Please
+<p ><b><span >2.2 Why you should read them.</span></b><span>&nbsp;Please
 read this Agreement carefully before you start to use our Services. This
 Agreement (always together with the documents referred to in it) tells you who
 we are, how we will provide the Services to you, how this Agreement may be
 changed or ended, what to do if there is a problem and other important
 information. If you think that there is a mistake in this Agreement or require
-any changes, please&nbsp;</span><a href="https://transferwise.com/contact"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>contact us</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;to
+any changes, please&nbsp;</span><a href="https://transferwise.com/contact"><b><span>contact us</span></b></a><span>&nbsp;to
 discuss.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.3 Other additional documents which
-apply to you.&nbsp;</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>This Agreement refers to the following
+<p ><b><span >2.3 Other additional documents which
+apply to you.&nbsp;</span></b><span >This Agreement refers to the following
 additional documents, which also apply to your use of our Services:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a)&nbsp;</span><a
-href="https://transferwise.com/privacy-policy-tw-europe"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Our Privacy Policy</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>,
+<p><span >(a)&nbsp;</span><a
+href="https://transferwise.com/privacy-policy-tw-europe"><b><span>Our Privacy Policy</span></b></a><span>,
 which sets out the terms on which we process any personal data we collect about
 you, or that you provide to us. By using our Services, you consent to such
 processing and you promise that all data provided by you is accurate.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(b)&nbsp;</span><a
-href="https://transferwise.com/cookie-policy"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Our Cookie Policy</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>, which sets out information about the
+<p><span >(b)&nbsp;</span><a
+href="https://transferwise.com/cookie-policy"><b><span >Our Cookie Policy</span></b></a><span >, which sets out information about the
 “cookies” on our Website.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(c)&nbsp;</span><a
-href="https://transferwise.com/gb/legal/acceptable-use-policy-eea"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Our Acceptable Use
-Policy</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>, which sets out the permitted uses and
+<p><span >(c)&nbsp;</span><a
+href="https://transferwise.com/gb/legal/acceptable-use-policy-eea"><b><span>Our Acceptable Use
+Policy</span></b></a><span >, which sets out the permitted uses and
 prohibited uses of our Services.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(d)&nbsp;</span><a href="https://transferwise.com/help"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Our Frequently Asked
-Questions</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;(&quot;FAQ&quot;) which provides
+<p><span >(d)&nbsp;</span><a href="https://transferwise.com/help"><b><span>Our Frequently Asked
+Questions</span></b></a><span >&nbsp;(&quot;FAQ&quot;) which provides
 answers to common customer questions.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(e) In order to receive some of our
+<p ><span >(e) In order to receive some of our
 Services, you may be asked to agree to additional terms and conditions
 (including those referred to in section 29) which we will notify you about at
 the relevant time.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.4 Additional documents.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;For
+<p ><b><span >2.4 Additional documents.</span></b><span>&nbsp;For
 clarity, the additional documents and the parts of this Agreement which
 incorporate the additional documents are not Framework Contracts.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.5 Future changes to this Agreement.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;All
+<p ><b><span >2.5 Future changes to this Agreement.</span></b><span>&nbsp;All
 future changes set out in the&nbsp;</span><a
-href="https://transferwise.com/customer-updates"><b><span style='font-family:
-"Avenir W02",sans-serif;color:#00B9FF'>Customer Updates section</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;of
+href="https://transferwise.com/customer-updates"><b><span >Customer Updates section</span></b></a><span>&nbsp;of
 our Website at the time you sign-up for our Services are incorporated into this
 Agreement. This Agreement may be changed from time to time as set out in
 section 26 of this Agreement.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.6 You accept this Agreement.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;By
+<p ><b><span >2.6 You accept this Agreement.</span></b><span>&nbsp;By
 visiting our Website and/or using our Services (including downloading and using
 our App, or via the API, a social media platform or other authorised third
 party), you confirm that you accept and agree to this Agreement (including the
 Customer Updates and the additional documents referred to above). If you do not
 agree, please do not use our Services.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>2.7 Where to get a copy of this
-Agreement.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You can always see the most current
-version of&nbsp;</span><a href="https://transferwise.com/terms-of-use-tw-europe"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>this Agreement</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;on
+<p ><b><span >2.7 Where to get a copy of this
+Agreement.</span></b><span >&nbsp;You can always see the most current
+version of&nbsp;</span><a href="https://transferwise.com/terms-of-use-tw-europe"><b><span>this Agreement</span></b></a><span>&nbsp;on
 our Website. If you want a paper copy of this Agreement, please contact&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>3.
+<p ><b><span>3.
 Glossary</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>In this Agreement:</span></p>
+<p ><span >In this Agreement:</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>API</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means the
+<p ><b><span >API</span></b><span >&nbsp;means the
 application programming interface provided by TransferWise.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>App</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means the
+<p ><b><span >App</span></b><span >&nbsp;means the
 mobile application software, the data supplied with the software and the
 associated media.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Balance</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Balance</span></b><span>&nbsp;means
 any amounts held in your TransferWise Account.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Book II Criminal Code</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Book II Criminal Code</span></b><span>&nbsp;means
 the provisions on cybercrime in Book II of the Belgian Code of Criminal Law.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Book VII CEL</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Book VII CEL</span></b><span>&nbsp;means
 the provisions on payment services in Book VII of the Belgian Code of Economic
 Law.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Business Day</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Business Day</span></b><span>&nbsp;means
 a day other than a Saturday, Sunday or a public holiday in Belgium when
 financial institutions in Brussels are open for business.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Framework Contract&nbsp;</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>means
+<p ><b><span >Framework Contract&nbsp;</span></b><span>means
 a contract for payment services which governs the future execution of
 individual and successive payment transactions and which may contain the
 obligation and conditions for setting up a payment account as defined in the
 Second Payment Services Directive (2015/2366, &quot;PSD2&quot;) or any
 implementation of PSD2 in any EU or EEA Member State.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Group Company</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Group Company</span></b><span>&nbsp;means
 any entity that directly or indirectly controls, is controlled by, or is under
 common control with another entity.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>PIL</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means the
+<p ><b><span >PIL</span></b><span >&nbsp;means the
 Belgian Law on Payment Institutions and E-money Institutions of 11 March 2018.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Services</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Services</span></b><span>&nbsp;means
 all products, services, content, features, technologies or functions offered by
 us and all related websites, applications (including the App), and services
 (including the Website and API).</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Source Currency</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Source Currency</span></b><span>&nbsp;means
 the currency which you hold and/or fund your payment order with.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Target Currency</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Target Currency</span></b><span>&nbsp;means
 the currency which your recipient will receive.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>TransferWise Account</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >TransferWise Account</span></b><span>&nbsp;means
 the account you have opened with us in accordance with the terms of this
 Agreement.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>Website</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;means
+<p ><b><span >Website</span></b><span>&nbsp;means
 any webpage, including but not limited to www.transferwise.com, where we
 provide the Services to you.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>4.
+<p ><b><span>4.
 TransferWise App and API</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>4.1 App subject to this Agreement and
-the App store Rules.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We license the use of the App to you
+<p ><b><span >4.1 App subject to this Agreement and
+the App store Rules.</span></b><span >&nbsp;We license the use of the App to you
 on the basis of this Agreement and subject to any rules and policies applied by
 any appstore provider or operator whose sites are located at&nbsp;</span><a
-href="https://www.apple.com/uk/legal/internet-services/itunes/uk/terms.html"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>App Store</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;and&nbsp;</span><a
-href="https://play.google.com/intl/en_uk/about/play-terms.html"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Google Play</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.
+href="https://www.apple.com/uk/legal/internet-services/itunes/uk/terms.html"><b><span>App Store</span></b></a><span>&nbsp;and&nbsp;</span><a
+href="https://play.google.com/intl/en_uk/about/play-terms.html"><b><span>Google Play</span></b></a><span>.
 We do not sell the App to you. We remain the owners of the App at all times.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>4.2 App updates.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;From
+<p ><b><span >4.2 App updates.</span></b><span>&nbsp;From
 time to time updates to the App may be issued through App Store or Google Play.
 Depending on the update, you may not be able to use our Services via the App
 until you have downloaded the latest version of the App and accepted any new
 terms.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>4.3 Your right to use the App and the
-API.&nbsp;</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>In consideration of you agreeing to abide by
+<p ><b><span >4.3 Your right to use the App and the
+API.&nbsp;</span></b><span >In consideration of you agreeing to abide by
 the terms of this Agreement, we grant you a non-transferable, non-exclusive
 licence to use the App on your device and the API subject to this Agreement. We
 reserve all other rights.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>5.
+<p ><b><span>5.
 Who are we and how to contact us</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>5.1 Our company information.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;TransferWise
+<p ><b><span >5.1 Our company information.</span></b><span>&nbsp;TransferWise
 Europe NV/SA is a company incorporated under the law of Belgium with company
 number 0713.629.988 (&quot;TransferWise&quot;, &quot;we&quot;, &quot;us&quot;,
 or &quot;our&quot; as applicable).</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>5.2 Our Belgian Registered office.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Our
+<p ><b><span >5.2 Our Belgian Registered office.</span></b><span>&nbsp;Our
 registered office is TransferWise Europe SA/NV, Avenue Louise 54, Room s52,
 1050 Brussels, Belgium.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>5.3 We are authorised by the NBB.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >5.3 We are authorised by the NBB.</span></b><span>&nbsp;We
 are authorised as a payment institution by the National Bank of Belgium
 (&quot;NBB&quot;) under the PIL.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>5.4 How to contact us.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >5.4 How to contact us.</span></b><span>&nbsp;You
 can contact us by email, web chat or telephone. Our contact details are
-provided on the&nbsp;</span><a href="https://transferwise.com/contact"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>&quot;Contact&quot;</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;page
+provided on the&nbsp;</span><a href="https://transferwise.com/contact"><b><span>&quot;Contact&quot;</span></b></a><span>&nbsp;page
 of our Website.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>6.
+<p ><b><span>6.
 Who can use our Services</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>6.1 You must be 18 years or over.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If
+<p ><b><span >6.1 You must be 18 years or over.</span></b><span>&nbsp;If
 you are an individual, you must be 18 years or older to use our Services and by
 opening a TransferWise Account you declare that you are 18 years or older. We
 may ask you at any time to show proof of your age.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>6.2 You must have authority to bind your
-business.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;If you are not a consumer, you confirm
+<p ><b><span >6.2 You must have authority to bind your
+business.</span></b><span >&nbsp;If you are not a consumer, you confirm
 that you have authority to bind any business or entity on whose behalf you use
 our Services, and that business or entity accepts these terms.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>6.3 Your use of the TransferWise Account
-must not violate any applicable laws.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You commit to us that your opening
+<p ><b><span >6.3 Your use of the TransferWise Account
+must not violate any applicable laws.</span></b><span >&nbsp;You commit to us that your opening
 and/or using of a TransferWise Account does not violate any laws applicable to
 you. You take responsibility for any consequences of your breach of this
 section.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>7.
+<p ><b><span>7.
 Your TransferWise Account</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>7.1 About your TransferWise Account</span></b></p>
+<p ><b><span >7.1 About your TransferWise Account</span></b></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) Your TransferWise Account allows you to hold, send or
+<p><span >(a) Your TransferWise Account allows you to hold, send or
 receive funds.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(b) The funds held on your TransferWise Account does not
+<p><span >(b) The funds held on your TransferWise Account does not
 expire other than when your account is closed, see section 19 for more details.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(c) The funds held on your TransferWise Account will not
+<p><span >(c) The funds held on your TransferWise Account will not
 earn any interest.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(d) You may hold your funds in any currencies which we
+<p><span >(d) You may hold your funds in any currencies which we
 support from time to time.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(e) You may withdraw money from your TransferWise Account
+<p><span >(e) You may withdraw money from your TransferWise Account
 at any time, subject to certain conditions, please see section 16 for more
 details.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(f) Certain limits may be placed on your TransferWise
+<p><span >(f) Certain limits may be placed on your TransferWise
 Account depending on your country of residence, verification checks or other
 legal considerations. Please&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>contact us</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;if you have any questions about these
+href="https://transferwise.com/contact"><b><span >contact us</span></b></a><span >&nbsp;if you have any questions about these
 limits.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(g) The funds held on your TransferWise Account belongs to
+<p><span >(g) The funds held on your TransferWise Account belongs to
 the person or legal entity which is registered as the TransferWise Account
 holder.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(h) Unless you have our consent in writing,
+<p ><span >(h) Unless you have our consent in writing,
 you must not allow anyone to operate your TransferWise Account on your behalf.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>7.2</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Your funds in
+<p ><b><span >7.2</span></b><span >&nbsp;Your funds in
 the TransferWise Account are treated in accordance with the EU Payment Services
 Directive and the PIL.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>7.3</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Your
+<p ><b><span >7.3</span></b><span >&nbsp;Your
 TransferWise Account is a payment account and is not a bank (deposit) account.
 You acknowledge that the Belgian Deposit Guarantee Scheme does not apply to
 your TransferWise Account. However, we follow the requirements under the EU
 Payment Services Directive 2015/2366 (PSD2) and the PIL which are designed to
 ensure the safety of funds held in payment accounts like your TransferWise
 Account. For further information on how we look after your money, please
-visit&nbsp;</span><a href="https://transferwise.com/help"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+visit&nbsp;</span><a href="https://transferwise.com/help"><b><span>FAQ</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>8.
+<p ><b><span>8.
 Getting started</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>8.1 Open a TransferWise Account.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;To
+<p ><b><span >8.1 Open a TransferWise Account.</span></b><span>&nbsp;To
 start using our Services, you must open a TransferWise Account and provide your
 details as prompted.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>8.2 Information must be accurate.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;All
+<p ><b><span >8.2 Information must be accurate.</span></b><span>&nbsp;All
 information you provide to us must be complete, accurate and truthful at all
 times. You must update this information whenever it changes. We cannot be
 responsible for any financial loss arising out of your failure to do so. We may
 ask you at any time to confirm the accuracy of your information and/or to
 provide additional supporting documents.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>8.3 Transacting on your own account.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;All
+<p ><b><span >8.3 Transacting on your own account.</span></b><span>&nbsp;All
 activities under a TransferWise Account shall be deemed as activities carried
 out by the registered user. You shall only use the Services to transact on your
 own account and not on behalf of any other person or entity.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>8.4 One account per person or entity.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >8.4 One account per person or entity.</span></b><span>&nbsp;You
 may only open one TransferWise Account unless we have agreed in writing the
 opening of additional accounts. TransferWise may refuse the creation of
 duplicate accounts for the same user. Where duplicate accounts are detected,
 TransferWise may close or merge these duplicate accounts at its sole
 discretion.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>9.
+<p ><b><span>9.
 Getting to know you</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>9.1</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We are
+<p ><b><span >9.1</span></b><span >&nbsp;We are
 required by law to carry out all necessary security and customer due diligence
 checks on you (including any parties involved in your transaction for example
 your recipient) in order to provide any Services to you. You agree to comply
@@ -465,90 +296,61 @@ from time to time, to establish, update, or renew your TransferWise Account
 with us or in the event of a dispute relating to this Agreement and activity
 under your TransferWise Account.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>10.
+<p ><b><span>10.
 Keep your TransferWise Account safe</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>10.1 Keep your TransferWise Account safe</span></b></p>
+<p ><b><span >10.1 Keep your TransferWise Account safe</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>(i) What to do.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >(i) What to do.</span></b><span>&nbsp;You
 must:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) Change your password regularly and ensure that it
+<p><span >(a) Change your password regularly and ensure that it
 isn’t reused across other online accounts.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(b) Contact&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;if anyone asks for your TransferWise
+<p><span >(b) Contact&nbsp;</span><a
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >&nbsp;if anyone asks for your TransferWise
 password.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(c) Always follow recommended password management
+<p><span >(c) Always follow recommended password management
 practice, for example:&nbsp;</span><a
-href="https://support.google.com/accounts/answer/32040?hl=en"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>https://support.google.com/accounts/answer/32040?hl=en</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://support.google.com/accounts/answer/32040?hl=en"><b><span>https://support.google.com/accounts/answer/32040?hl=en</span></b></a><span>.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(d) Set up 2-step authentication where prompted (for
+<p><span >(d) Set up 2-step authentication where prompted (for
 further instructions please refer to our&nbsp;</span><a
-href="https://transferwise.com/help/article/2738229/other/2-step-login"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>).</span></p>
+href="https://transferwise.com/help/article/2738229/other/2-step-login"><b><span>FAQ</span></b></a><span>).</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(e) Keep your e-mail account secure. You may
+<p ><span >(e) Keep your e-mail account secure. You may
 reset your TransferWise Account password using your email address. Let&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;know immediately if your email address
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >&nbsp;know immediately if your email address
 becomes compromised.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>(ii) What NOT to do.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >(ii) What NOT to do.</span></b><span>&nbsp;You
 must NOT:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) Disclose your TransferWise Account password or your
+<p><span >(a) Disclose your TransferWise Account password or your
 customer reference number (which starts with the letter P followed by a series
 of numbers). Keep them safe.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(b) Let anyone access your TransferWise Account or watch
+<p><span >(b) Let anyone access your TransferWise Account or watch
 you accessing it.</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(c) Use any functionality that allows your login details
+<p><span >(c) Use any functionality that allows your login details
 or passwords to be stored by the computer or browser you are using or to be
 cached or otherwise recorded.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(d) Do anything which may in any way avoid
+<p ><span >(d) Do anything which may in any way avoid
 or compromise the 2-step authentication process.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>10.2 Contact us if you suspect your
-TransferWise Account has been compromised.</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If you suspect
+<p ><b><span >10.2 Contact us if you suspect your
+TransferWise Account has been compromised.</span></b><span >&nbsp;If you suspect
 your TransferWise Account or other security credentials are stolen, lost, used
 without your authorisation or otherwise compromised, you must contact&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;immediately, you are also advised to
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >&nbsp;immediately, you are also advised to
 change your password. Any undue delays in notifying us may affect the security
 of your TransferWise Account and also result in you being responsible for
 financial losses.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>10.3 Authorising third parties.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >10.3 Authorising third parties.</span></b><span>&nbsp;You
 may authorise third parties to access your TransferWise Account to provide
 their services to you, including authorising them to initiate payments from
 your TransferWise Account. You acknowledge that if you authorise a third party
@@ -559,27 +361,20 @@ TransferWise Account. Granting permission to a third party does not relieve you
 of your responsibilities under this Agreement, including notifying us if your TransferWise
 Account has been compromised or if a transaction is incorrect or unauthorised.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>11.
+<p ><b><span>11.
 Uploading money into your TransferWise Account</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>11.1 How to upload money into your
-TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;To upload money, you need to log in to
+<p ><b><span >11.1 How to upload money into your
+TransferWise Account.</span></b><span >&nbsp;To upload money, you need to log in to
 your TransferWise Account and follow the steps as they appear on screen. We are
 not responsible for the money you have uploaded until we have received them.
 For clarity, in an upload transaction, we are the recipient of funds and not
 the payment services provider.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>11.2 Payin Methods.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >11.2 Payin Methods.</span></b><span>&nbsp;You
 may be presented with one or more methods of upload for example, bank transfer,
 credit cards or debit cards (in this Agreement, we will call these
-methods&nbsp;</span><b><span style='font-family:"Avenir W02",sans-serif;
-color:#2E4369'>“Payin Methods”</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>). The number of Payin Methods made
+methods&nbsp;</span><b><span >“Payin Methods”</span></b><span >). The number of Payin Methods made
 available to you will depend on a number of factors including where you live
 and your verification status with us. Payin Methods are not part of our
 Services, they are services provided by third parties for example the card
@@ -587,45 +382,34 @@ provider which issued you with your credit/debit card. We cannot guarantee the
 use of any particular Payin Method and may change or stop offering a Payin
 Method at any time without notice to you.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>11.3 Payment instrument must be in your
-name.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;Any payment instrument (for example, the credit card
+<p ><b><span >11.3 Payment instrument must be in your
+name.</span></b><span >&nbsp;Any payment instrument (for example, the credit card
 or debit card) you use with your chosen Payin Method must be in your name.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>11.4 Chargebacks on your payment
-instrument.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;If you selected a Payin Method which
+<p ><b><span >11.4 Chargebacks on your payment
+instrument.</span></b><span >&nbsp;If you selected a Payin Method which
 gives you chargeback rights (for example in relation to your credit card, you
 may ask your card provider to reverse a transaction on your card), you promise
 that you will only exercise this chargeback right if:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) we have breached this Agreement; or</span></p>
+<p><span >(a) we have breached this Agreement; or</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(b) there was an unauthorised use of your
+<p ><span >(b) there was an unauthorised use of your
 payment instrument.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>You promise that you will not exercise your
+<p ><span >You promise that you will not exercise your
 chargeback right for reasons which we are not responsible, including a dispute
 with your recipient or if there are insufficient funds in your payment
 instrument. If we need to investigate or take any actions in connection with a
 chargeback raised by you, we may charge you for our costs in doing so and may
 deduct such amount from your TransferWise Account.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>11.5 Upload limits on your TransferWise
-Account.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;For legal and security reasons, we impose limits on
+<p ><b><span >11.5 Upload limits on your TransferWise
+Account.</span></b><span >&nbsp;For legal and security reasons, we impose limits on
 how much you can upload into your TransferWise Account.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>11.6 When we will credit your
-TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We will credit your TransferWise
+<p ><b><span >11.6 When we will credit your
+TransferWise Account.</span></b><span >&nbsp;We will credit your TransferWise
 Account once we have received your money. For some Payin Methods such as credit
 or debit card, we will credit the money to your TransferWise Account as soon as
 possible subject to our right of reversal. This means if the actual amount you
@@ -634,150 +418,104 @@ such amount from your TransferWise Account. If you do not have enough money in
 your TransferWise Account for this purpose, we can demand repayment from you
 using other methods.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>12.
+<p ><b><span>12.
 Sending money</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.1 Setting up your payment order</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >12.1 Setting up your payment order</span></b><span>&nbsp;You
 must set up your payment order from your TransferWise Account. Your order may
 either be:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) a&nbsp;</span><b><span style='font-family:"Avenir W02",sans-serif;
-color:#2E4369'>&quot;Fixed Source Order&quot;</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;which is a
+<p><span >(a) a&nbsp;</span><b><span >&quot;Fixed Source Order&quot;</span></b><span >&nbsp;which is a
 payment order where you indicate that you wish to send and convert a fixed
 amount of Source Currency to your recipient who will receive the converted
 amount in the Target Currency; or</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(b) a&nbsp;</span><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>&quot;Fixed Target Order&quot;</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;which
+<p ><span >(b) a&nbsp;</span><b><span >&quot;Fixed Target Order&quot;</span></b><span>&nbsp;which
 is a transfer where you indicate that you wish to send and convert a fixed
 amount of Target Currency to your recipient from the Source Currency you pay
 into TransferWise.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>You can only set up a Fixed Target Order for
+<p ><span >You can only set up a Fixed Target Order for
 certain Source Currencies, you can find a list of these Source Currencies on
 our&nbsp;</span><a
-href="https://transferwise.com/help/article/1652630/creating-a-transfer/specific-amount-transfer"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/help/article/1652630/creating-a-transfer/specific-amount-transfer"><b><span>FAQ</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.2 Information you need to provide to
-set up a payment order.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;To set up a payment order via your
+<p ><b><span >12.2 Information you need to provide to
+set up a payment order.</span></b><span >&nbsp;To set up a payment order via your
 TransferWise Account, you need to provide certain information to us including
 (a) the full name of your recipient, (b) your recipient’s bank account details
 or their TransferWise Account details and (c) the amount to be transferred.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.3 Payment order limits.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >12.3 Payment order limits.</span></b><span>&nbsp;We
 may place limits on the amount you may send per transfer. For more information
 on the applicable limits, please visit our&nbsp;</span><a
-href="https://transferwise.com/help"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>FAQ</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/help"><b><span >FAQ</span></b></a><span >.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.4 When is your payment order
-received.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;If your payment order is received by
+<p ><b><span >12.4 When is your payment order
+received.</span></b><span >&nbsp;If your payment order is received by
 us after 5pm on a Business Day or not on a Business Day, your payment order
 will be deemed received on the following Business Day.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.5 What happens after you have
-submitted your payment order.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;Once we have received your payment
+<p ><b><span >12.5 What happens after you have
+submitted your payment order.</span></b><span >&nbsp;Once we have received your payment
 order, we will display it under the Activity section of your TransferWise account.
 Each payment order is given a unique transaction number which you can find
 there. You should quote this number when communicating with us about a
 particular payment order.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.6 You need to provide us with
-sufficient funds before we can process your payment order.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >12.6 You need to provide us with
+sufficient funds before we can process your payment order.</span></b><span>&nbsp;We
 will only process your payment order if we hold or have received sufficient
 cleared funds in your TransferWise Account. It is your responsibility to fund
 your payment order in a timely manner. We cannot be responsible for the time it
 takes for the money to be sent to us by your bank or payment service provider.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.7 Verification checks may increase
-the time for processing your payment order.</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We carry out
+<p ><b><span >12.7 Verification checks may increase
+the time for processing your payment order.</span></b><span >&nbsp;We carry out
 verification checks, and these checks may increase the time it takes to process
 your payment order. We cannot be responsible for any delays as a result of
 carrying out those checks.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.8 Completion time of your payment
-order.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;The estimated completion time of your payment order
+<p ><b><span >12.8 Completion time of your payment
+order.</span></b><span >&nbsp;The estimated completion time of your payment order
 is notified to you when you complete the setup of your payment order. You may
 also find further information about the completion time in the&nbsp;</span><a
-href="https://transferwise.com/help"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>FAQ</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;section of our Website, please refer
+href="https://transferwise.com/help"><b><span >FAQ</span></b></a><span >&nbsp;section of our Website, please refer
 to the applicable currencies in your payment order.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.9 We will use reasonable efforts to
-ensure funds arrive at your recipient’s account within the notified timeframe.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >12.9 We will use reasonable efforts to
+ensure funds arrive at your recipient’s account within the notified timeframe.</span></b><span>&nbsp;We
 will use reasonable efforts to ensure that the funds arrive in the recipient’s
 bank account or payment account within the timelines notified to you or
-otherwise specified in our&nbsp;</span><a href="https://transferwise.com/help"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>FAQ</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;section.
+otherwise specified in our&nbsp;</span><a href="https://transferwise.com/help"><b><span>FAQ</span></b></a><span>&nbsp;section.
 We do not have any control over the time it may take for the recipient’s bank
 or payment provider to credit and make available funds to the recipient.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.10 Refusal of your payment order.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If
+<p ><b><span >12.10 Refusal of your payment order.</span></b><span>&nbsp;If
 we are unable to complete your payment order, we will let you know and, if
 possible, the reasons for the refusal and an explanation of how to correct any
 factual errors. However, we are not required to notify you if such notification
 would be unlawful.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.11 You may cancel your payment order
-before your funds are converted.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You may cancel your payment order by
+<p ><b><span >12.11 You may cancel your payment order
+before your funds are converted.</span></b><span >&nbsp;You may cancel your payment order by
 following the instructions set out in our&nbsp;</span><a
-href="https://transferwise.com/help"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>FAQ</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>. You cannot cancel your payment order once
+href="https://transferwise.com/help"><b><span >FAQ</span></b></a><span >. You cannot cancel your payment order once
 your funds have been converted into the Target Currency you requested.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.12 You must ensure the information
-you provide to us is correct.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You must make sure that the
+<p ><b><span >12.12 You must ensure the information
+you provide to us is correct.</span></b><span >&nbsp;You must make sure that the
 information you provide when setting up a payment order is accurate. If we have
 processed your order in accordance with the information you have provided to us
 it will be considered correctly completed even if you have made a mistake.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.13 What happens if you provide us
-with incorrect information.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;If you provide incorrect information
+<p ><b><span >12.13 What happens if you provide us
+with incorrect information.</span></b><span >&nbsp;If you provide incorrect information
 with your payment order, we will use reasonable efforts to recover the funds
 for you, and may need to charge you a fee for that.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>12.14 When will I be notified of my next
-scheduled transfer.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;If you have scheduled a transfer in
+<p ><b><span >12.14 When will I be notified of my next
+scheduled transfer.</span></b><span >&nbsp;If you have scheduled a transfer in
 advance then we will notify you 24 hours before your upcoming transfer, setting
 out the total fees and the estimated ‘live’ exchange rate for that transfer. By
 scheduling a transfer, you agree to TW sending the funds using the live
@@ -785,87 +523,64 @@ exchange rate at any time on the scheduled date. If you have opted in to
 receiving emails, we will send you a transfer receipt after successfully
 sending your scheduled transfer. For more information on scheduled transfers
 see our&nbsp;</span><a
-href="https://transferwise.com/help/a/2978063/what-are-scheduled-transfers"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Help Centre</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/help/a/2978063/what-are-scheduled-transfers"><b><span>Help Centre</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>13.
+<p ><b><span>13.
 Exchange Rates</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>13.1 The applicable exchange rate.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >13.1 The applicable exchange rate.</span></b><span>&nbsp;We
 will let you know the exchange rate:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) when you place your payment order, if it is a
+<p><span >(a) when you place your payment order, if it is a
 guaranteed rate payment order; or</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(b) when we have received your payment, if
+<p ><span >(b) when we have received your payment, if
 it is a non-guaranteed rate payment order.</span></p>
 
-<p class=MsoNormal><b><span style='font-family:"Avenir W02",sans-serif;
-color:#2E4369'>13.2 Exchange rate</span></b></p>
+<p><b><span >13.2 Exchange rate</span></b></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) Except as specified in section 13.2(b) below, when we
+<p><span >(a) Except as specified in section 13.2(b) below, when we
 refer to an exchange rate in this Agreement, it means the mid-market exchange
 rate at the relevant time for the relevant currency pair (for example, GBP to
 EUR, USD to AUD) as provided by our reference rate provider, Reuters. We may
 change our reference rate provider from time to time without notice to you.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(b) For some currencies, we cannot use the
+<p ><span >(b) For some currencies, we cannot use the
 mid-market exchange rate as we are required to use a different reference rate
 for the exchange rate for your currency pair. For example, for transfers to
 Nigeria (NGN), we are required to use the rate set by the Central Bank of Nigeria.
 For these currencies we will notify you of the reference rate used for the
 exchange rate when you place your payment order.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>13.3 Guaranteed rates.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >13.3 Guaranteed rates.</span></b><span>&nbsp;We
 offer automatic guaranteed rates on certain payment orders based on the table
 and subject to the conditions&nbsp;</span><a
-href="https://transferwise.com/guaranteed-rate-conditions"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>here</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>,
+href="https://transferwise.com/guaranteed-rate-conditions"><b><span>here</span></b></a><span>,
 which may be changed from time to time.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>14.
+<p ><b><span>14.
 Receiving money</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>14.1 You can receive money into your
-TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You can receive money into your
+<p ><b><span >14.1 You can receive money into your
+TransferWise Account.</span></b><span >&nbsp;You can receive money into your
 TransferWise Account using methods which we support from time to time.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>14.2 The money received is shown in your
-TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;Any money you receive into your
+<p ><b><span >14.2 The money received is shown in your
+TransferWise Account.</span></b><span >&nbsp;Any money you receive into your
 TransferWise Account will be recorded in the transaction history section of
 your TransferWise Account. You should check the incoming funds in your
 TransferWise Account against your own records regularly and let us know if
 there are any irregularities.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>14.3 The money received may be subject
-to reversal.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You acknowledge that the money
+<p ><b><span >14.3 The money received may be subject
+to reversal.</span></b><span >&nbsp;You acknowledge that the money
 received in your TransferWise Account (&quot;Received Amount&quot;) may be
 subject to reversal and you agree that we may deduct the Received Amount from
 your TransferWise Account if it was reversed by the person who paid you the
 Received Amount or any relevant payment services provider.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>14.4 Sending money using an email
-address.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;If you send money to a person using an email address
+<p ><b><span >14.4 Sending money using an email
+address.</span></b><span >&nbsp;If you send money to a person using an email address
 which is not registered with us, the money will not be credited until the
 intended recipient has claimed the money following the steps we have set out
 for them. Until then, there is no relationship between us and the intended
@@ -873,42 +588,33 @@ recipient and the money continues to belong to you. We will refund the money to
 you if the intended recipient does not claim the money or if they have failed
 our customer checks within a reasonable time period as determined by us.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>15.
+<p ><b><span>15.
 Maintaining your TransferWise Account</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>15.1 Transaction history is displayed on
-your TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;All your transactions (including your
+<p ><b><span >15.1 Transaction history is displayed on
+your TransferWise Account.</span></b><span >&nbsp;All your transactions (including your
 current Balance, money you have uploaded, received, sent and/or withdrawn) are
 recorded in the transaction history section of your TransferWise Account. You
 may access this information after you log in to your TransferWise Account. We
 have allocated a reference number to each transaction, you should quote this
 reference number when communicating with us about a particular transaction.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>15.2 Check your TransferWise Account
-regularly.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You must check your TransferWise
+<p ><b><span >15.2 Check your TransferWise Account
+regularly.</span></b><span >&nbsp;You must check your TransferWise
 Account regularly and carefully and contact us immediately if you don’t
 recognise a transaction or think we have made a payment incorrectly. You must
 tell us about any unauthorised or incorrectly executed transactions
 immediately, but no later than thirteen (13) months from the transaction;
 otherwise you may not be entitled to have any errors corrected.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>15.3 You accept the risks of holding
-balances in multiple currencies.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree and accept all the risks
+<p ><b><span >15.3 You accept the risks of holding
+balances in multiple currencies.</span></b><span >&nbsp;You agree and accept all the risks
 associated with maintaining Balances in multiple currencies including any risks
 associated with fluctuations in the relevant exchange rates over time. You agree
 that you will not use our Services for speculative trading.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>15.4 No negative Balance in your
-TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You promise to always have a zero or
+<p ><b><span >15.4 No negative Balance in your
+TransferWise Account.</span></b><span >&nbsp;You promise to always have a zero or
 positive Balance in your TransferWise Account. If your TransferWise Account
 goes into a negative Balance as a result of a chargeback, reversal of a
 transaction, deduction of fees or any other action carried by you, you promise
@@ -918,34 +624,25 @@ negative Balance from you, for example, we may use a debt collection service or
 take further legal actions. We will charge you for any costs we may incur as a
 result of these additional collection efforts.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>15.5 Taxes.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >15.5 Taxes.</span></b><span>&nbsp;You
 are responsible for any taxes which may be applicable to payments you make or
 receive, and it is your responsibility to collect, report and pay the correct
 tax to the appropriate tax authority.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>16.
+<p ><b><span>16.
 Withdrawing from your TransferWise Account</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>16.1 You can request to withdraw your
-money.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;After you log in to your TransferWise Account, you
+<p ><b><span >16.1 You can request to withdraw your
+money.</span></b><span >&nbsp;After you log in to your TransferWise Account, you
 may request all or part of your money held in your TransferWise Account to be
 withdrawn. Press &quot;send money&quot; and follow the steps as prompted on
 screen. We will charge you a fee for each withdrawal request where this is
 permissible by law, we will let you know the exact amount when you submit your
 request. You can also find out more information about the fees we charge on
 the&nbsp;</span><a
-href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Pricing page</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span>Pricing page</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>16.2 Payout Methods available to you.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >16.2 Payout Methods available to you.</span></b><span>&nbsp;You
 may be presented with one or more methods of withdrawal (in this Agreement, we
 will call these methods &quot;Payout Methods&quot;). The number of Payout
 Methods made available to you will depend on a number of factors including
@@ -954,131 +651,93 @@ use of any particular Payout Method and may change or stop offering a Payout
 Method at any time without notice to you, but we will ensure that you will
 always have at least one Payout Method available to you.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>16.3 You must provide correct
-information to us.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;When setting up your withdrawal
+<p ><b><span >16.3 You must provide correct
+information to us.</span></b><span >&nbsp;When setting up your withdrawal
 request, you must ensure that the information you provide is correct and complete.
 We will not be responsible for money sent to the wrong recipient as a result of
 incorrect information provided by you. If you have provided wrong information
 to us, you may ask us to assist you in recovering the money, but we cannot
 guarantee that such efforts will be successful.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>16.4 Your withdrawal request is subject
-to limits.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree that your TransferWise
+<p ><b><span >16.4 Your withdrawal request is subject
+to limits.</span></b><span >&nbsp;You agree that your TransferWise
 Account is subject to withdrawal limits. If your withdrawal request exceeds the
 current limit, we may decline your request and require you to provide
 additional documents to us so that we can carry out additional checks before
 allowing the money to be withdrawn.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>17.
+<p ><b><span>17.
 How much will you pay?</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>17.1 You must pay our fees.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >17.1 You must pay our fees.</span></b><span>&nbsp;You
 must pay the fees in connection with the use of our Services. We will not
 process your transaction until we have received the fees from you.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>17.2 You can see our fee structure on
-the Pricing page.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We will let you know the exact amount
+<p ><b><span >17.2 You can see our fee structure on
+the Pricing page.</span></b><span >&nbsp;We will let you know the exact amount
 payable by you when you set up your order. You can see our fee structure on
 the&nbsp;</span><a
-href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>&quot;Pricing&quot;
-page</span></b></a><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>. For clarity, the fees applicable to you as set out on
+href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span>&quot;Pricing&quot;
+page</span></b></a><span >. For clarity, the fees applicable to you as set out on
 the&nbsp;</span><a
-href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>&quot;Pricing&quot;
-page</span></b></a><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;forms part of this Agreement which may be subject to
+href="https://transferwise.com/help/article/2736166/borderless-account/borderless-account-pricing"><b><span>&quot;Pricing&quot;
+page</span></b></a><span >&nbsp;forms part of this Agreement which may be subject to
 change as set out in section 26.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>17.3 We can make deductions from your
-TransferWise Account.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree that we are authorised to
+<p ><b><span >17.3 We can make deductions from your
+TransferWise Account.</span></b><span >&nbsp;You agree that we are authorised to
 deduct our fees, any applicable reversal amounts, and/or any amounts you owe us
 from your TransferWise Account. If you don’t have enough money in your
 TransferWise Account to cover these amounts, we may refuse to execute the
 relevant transaction or provide any Services to you.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>18.
+<p ><b><span>18.
 Currency Conversion</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>18.1</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You may
+<p ><b><span >18.1</span></b><span >&nbsp;You may
 convert the money held in one currency in your TransferWise Account into other
 currencies we support from time to time. You can only perform a conversion in
 respect of funds that you already hold in your TransferWise Account. A conversion
 fee will apply when we perform a currency conversion, for more information,
-see&nbsp;</span><a href="https://transferwise.com/pricing"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>here</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+see&nbsp;</span><a href="https://transferwise.com/pricing"><b><span>here</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>19.
+<p ><b><span>19.
 Closing your TransferWise Account</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>19.1 You may close your TransferWise
-Account at any time.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You may end this Agreement and close
+<p ><b><span >19.1 You may close your TransferWise
+Account at any time.</span></b><span >&nbsp;You may end this Agreement and close
 your TransferWise Account at any time by contacting our&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>19.2 You should withdraw your money
-within a reasonable time.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;At the time of closure, if you still
+<p ><b><span >19.2 You should withdraw your money
+within a reasonable time.</span></b><span >&nbsp;At the time of closure, if you still
 have money in your TransferWise Account, you must withdraw your money within a
 reasonable period of time by following the steps described in section 16. After
 a reasonable period of time, you will no longer have access to your
 TransferWise Account, but you can still withdraw your money by contacting&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>. You have the right to do this for a period
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >. You have the right to do this for a period
 of six (6) years from the date your TransferWise Account is closed.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>19.3 You must not close your
-TransferWise Account to avoid an investigation.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >19.3 You must not close your
+TransferWise Account to avoid an investigation.</span></b><span>&nbsp;You
 must not close your TransferWise Account to avoid an investigation. If you
 attempt to close your TransferWise Account during an investigation, we may hold
 your money until the investigation is fully completed in order to protect our
 or a third party’s interest.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>19.4 You are responsible for your
-TransferWise Account after closure.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You agree that you will continue to be
+<p ><b><span >19.4 You are responsible for your
+TransferWise Account after closure.</span></b><span >&nbsp;You agree that you will continue to be
 responsible for all obligations related to your TransferWise Account even after
 it is closed.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>20.
+<p ><b><span>20.
 Intellectual property rights</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>20.1</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;While you are
+<p ><b><span >20.1</span></b><span >&nbsp;While you are
 using our Services, you may use the TransferWise Materials only for your
 personal use and solely as necessary in relation to those Services.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>20.2</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;&quot;TransferWise
+<p ><b><span >20.2</span></b><span >&nbsp;&quot;TransferWise
 Materials&quot; include any software (including without limitation the App, the
 API, developer tools, sample source code, and code libraries), data, materials,
 content and printed and electronic documentation (including any specifications
@@ -1087,33 +746,26 @@ available for download from our Website. You may not, and may not attempt to,
 directly or indirectly:</span></p>
 
 <ol start=1 type=a>
- <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>transfer, sublicense, loan, sell, assign, lease,
+ <li ><span >transfer, sublicense, loan, sell, assign, lease,
      rent, distribute or grant rights in the Services or the TransferWise
      Materials to any person or entity;</span></li>
- <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>remove, obscure, or alter any notice of any of our
+ <li ><span >remove, obscure, or alter any notice of any of our
      trade marks, or other &quot;intellectual property&quot; appearing on or
      contained within the Services or on any TransferWise Materials;</span></li>
- <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>modify, copy, tamper with or otherwise create
+ <li ><span >modify, copy, tamper with or otherwise create
      derivative works of any software included in the TransferWise Materials;
      or</span></li>
- <li class=MsoNormal style='color:#5D7079'><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>reverse engineer, disassemble, or decompile the
+ <li ><span >reverse engineer, disassemble, or decompile the
      TransferWise Materials or the Services or apply any other process or
      procedure to derive the source code of any software included in the
      TransferWise Materials or as part of the Services.</span></li>
 </ol>
 
-<p class=MsoNormal style='line-height:24.0pt'><b><span style='font-size:21.0pt;
-font-family:"Avenir W02",sans-serif;color:#2E4369'>21. Our responsibility for
+<p ><b><span >21. Our responsibility for
 loss or damage</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.1 We are responsible to you for
-foreseeable loss and damage caused by us.</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If we do not
+<p ><b><span >21.1 We are responsible to you for
+foreseeable loss and damage caused by us.</span></b><span >&nbsp;If we do not
 reasonably meet our commitments to you, we are responsible for loss or damage
 you suffer that is a foreseeable result of our breaking this contract or our
 failing to use reasonable care and skill. We are not responsible for any loss
@@ -1122,44 +774,33 @@ is obvious that it will happen or if, at the time the contract was made, both
 we and you knew it might happen, for example, if you discussed it with us
 during your account sign up process.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.2 We do not exclude or limit in any
-way our liability to you where it would be unlawful to do so.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;This
+<p ><b><span >21.2 We do not exclude or limit in any
+way our liability to you where it would be unlawful to do so.</span></b><span>&nbsp;This
 includes liability for death or personal injury caused by our negligence or the
 negligence of our employees, agents or subcontractors; for fraud or fraudulent
 misrepresentation.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.3 We are not liable for business
-losses.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;If you use our Services for any commercial or
+<p ><b><span >21.3 We are not liable for business
+losses.</span></b><span >&nbsp;If you use our Services for any commercial or
 business purpose we will have no liability to you for any loss of profit, loss
 of business, business interruption, or loss of business opportunity.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.4 We are not liable for technological
-attacks.</span></b><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>&nbsp;We will not be liable for any loss or damage caused
+<p ><b><span >21.4 We are not liable for technological
+attacks.</span></b><span >&nbsp;We will not be liable for any loss or damage caused
 by a virus, or other technological attacks or harmful material that may infect
 your computer equipment, computer programmes, data or other proprietary
 material related to your use of our Services.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.5 We have no control over websites
-linked to and from our Website.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We assume no responsibility for their
+<p ><b><span >21.5 We have no control over websites
+linked to and from our Website.</span></b><span >&nbsp;We assume no responsibility for their
 content or any loss or damage that may arise from your use of them.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.6 Our liability to you for
-unauthorised payments or our mistake.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;In case of an unauthorised payment or
+<p ><b><span >21.6 Our liability to you for
+unauthorised payments or our mistake.</span></b><span >&nbsp;In case of an unauthorised payment or
 mistake due to our error, we shall at your request immediately refund the
 payment amount including all fees deducted by us. This shall not apply:</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(a) where your TransferWise Account, or its
+<p ><span >(a) where your TransferWise Account, or its
 personalised security features, are lost, stolen or misappropriated. You will
 be liable for the first 50 EUR of any unauthorised payments if we believe you
 should have been aware of the loss, theft or unauthorised use. We will not hold
@@ -1170,56 +811,42 @@ apply to any unauthorised transactions made after you have notified us that
 your TransferWise Account may have been compromised (using the details we’ve
 given you);</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(b) if you have acted fraudulently, in which
+<p ><span >(b) if you have acted fraudulently, in which
 case we will not refund you in any circumstances;</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(c) if you do not quickly notify us of
+<p ><span >(c) if you do not quickly notify us of
 security issues on your TransferWise Account (e.g. loss of your password), you
 remain liable for losses incurred up to your notification to us;</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(d) if the payment transaction was
+<p ><span >(d) if the payment transaction was
 unauthorised but you have with intent or gross negligence compromised the
 security of your TransferWise Account or failed to comply with your obligations
 to use your TransferWise Account in the manner set out in this Agreement. In
 such a case you shall be solely liable for all losses; or</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(e) if you don’t let us know about the
+<p ><span >(e) if you don’t let us know about the
 unauthorised or incorrectly completed transaction within thirteen (13) months
 from the date of the payment transaction.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.7 You are responsible for checking
-your TransferWise Account regularly.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We rely on you to regularly check the
+<p ><b><span >21.7 You are responsible for checking
+your TransferWise Account regularly.</span></b><span >&nbsp;We rely on you to regularly check the
 transactions history of your TransferWise Account and to contact&nbsp;</span><a
-href="https://transferwise.com/contact"><b><span style='font-family:"Avenir W02",sans-serif;
-color:#00B9FF'>Customer Support</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;immediately in case you have any
+href="https://transferwise.com/contact"><b><span >Customer Support</span></b></a><span >&nbsp;immediately in case you have any
 questions or concerns.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.8 We are not liable for things which
-are outside of our control.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We (and our affiliates) cannot be
+<p ><b><span >21.8 We are not liable for things which
+are outside of our control.</span></b><span >&nbsp;We (and our affiliates) cannot be
 liable for our inability to deliver or delay as a result of things which are outside
 our control.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.9 You are liable for breaking this
-Agreement or applicable laws.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;In the unlikely event of loss or
+<p ><b><span >21.9 You are liable for breaking this
+Agreement or applicable laws.</span></b><span >&nbsp;In the unlikely event of loss or
 claims or costs and expenses arising out of your breach of this Agreement, any
 applicable law or regulation and/or your use of our Services, you agree to
 compensate us and our affiliates and hold us harmless. This provision will
 continue after our relationship ends.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>21.10 What happens if you owe us money.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;In
+<p ><b><span >21.10 What happens if you owe us money.</span></b><span>&nbsp;In
 the event you are liable for any amounts owed to us, we may immediately remove
 such amounts from your Balance (if available). If there are insufficient funds
 in your Balance to cover your liability, we reserve the right to collect your
@@ -1228,13 +855,10 @@ otherwise you agree to reimburse us through other means. We may also recover
 amounts you owe us through legal means, including, without limitation, through
 the use of a debt collection agency.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>22.
+<p ><b><span>22.
 Accessing our Services</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>22.1</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We will try to
+<p ><b><span >22.1</span></b><span >&nbsp;We will try to
 make sure our Services are available to you when you need them. However, we do
 not guarantee that our Services will always be available or be uninterrupted.
 We may suspend, withdraw, discontinue or change all or any part of our Services
@@ -1247,13 +871,10 @@ that third party. We will give you notice if we do this, either before or
 immediately after we refuse access, unless notifying you would be unlawful or
 compromise our reasonable security measures.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>23.
+<p ><b><span>23.
 Information security</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>23.1</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You are
+<p ><b><span >23.1</span></b><span >&nbsp;You are
 responsible for configuring your information technology, computer programmes
 and platform in order to access our Services. You should use your own virus
 protection software. We take security very seriously at TransferWise and we
@@ -1263,9 +884,7 @@ money to friends and family and to other people that you trust. However, we do
 advise you to consider very carefully before sending money to anyone that you
 do not know well.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>23.2 You must not misuse our Services.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;You
+<p ><b><span >23.2 You must not misuse our Services.</span></b><span>&nbsp;You
 must not misuse our Services by introducing viruses, trojans, worms, logic
 bombs or other materials which are malicious or technologically harmful. You
 must not attempt to gain unauthorised access to our Website, our servers,
@@ -1280,88 +899,63 @@ inappropriately, please contact us. Similarly, if you receive any emails,
 purporting to be from TransferWise, which you suspect may be phishing emails,
 please forward the email to our Customer Service.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>24.
+<p ><b><span>24.
 Linking to our site</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>24.1 You may link to our Website
-provided you follow certain rules.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You may link to our Website, provided:</span></p>
+<p ><b><span >24.1 You may link to our Website
+provided you follow certain rules.</span></b><span >&nbsp;You may link to our Website, provided:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) you do so in a way that is fair and legal and does not
+<p><span >(a) you do so in a way that is fair and legal and does not
 damage our reputation or take advantage of it;</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(b) you do not suggest any form of association, approval
+<p><span >(b) you do not suggest any form of association, approval
 or endorsement on our part where none exists;</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(c) you do not frame our Website on any other site; and</span></p>
+<p><span >(c) you do not frame our Website on any other site; and</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(d) the website complies with our&nbsp;</span><a
-href="https://transferwise.com/gb/legal/acceptable-use-policy-eea"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Acceptable Use Policy</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+<p ><span >(d) the website complies with our&nbsp;</span><a
+href="https://transferwise.com/gb/legal/acceptable-use-policy-eea"><b><span>Acceptable Use Policy</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>We reserve the right to withdraw linking
+<p ><span >We reserve the right to withdraw linking
 permission without notice.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>25.
+<p ><b><span>25.
 When we can end this Agreement or suspend our Services</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>25.1 We may end this Agreement by giving
-you two (2) months’ notice.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We may end this Agreement and close
+<p ><b><span >25.1 We may end this Agreement by giving
+you two (2) months’ notice.</span></b><span >&nbsp;We may end this Agreement and close
 your TransferWise Account or any service associated with it by giving you two
 (2) months’ prior notice.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>25.2 We may suspend or close your
-TransferWise Account without notice in certain circumstances.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;We
+<p ><b><span >25.2 We may suspend or close your
+TransferWise Account without notice in certain circumstances.</span></b><span>&nbsp;We
 may at any time suspend or close your TransferWise Account and/or end this
 Agreement without notice if:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) you breach any provision of this Agreement or
+<p><span >(a) you breach any provision of this Agreement or
 documents referred to in this Agreement;</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(b) we are requested or directed to do so by any competent
+<p><span >(b) we are requested or directed to do so by any competent
 court of law, government authority, public agency, or law enforcement agency;</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(c) we have serious reasons to believe you are in breach
+<p><span >(c) we have serious reasons to believe you are in breach
 of any applicable law or regulation; or</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(d) we have serious reasons to believe you
+<p ><span >(d) we have serious reasons to believe you
 are involved in any fraudulent activity, money laundering, terrorism financing
 or other criminal or illegal activity.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>25.3 We may suspend your TransferWise
-Account for security reasons.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We may suspend your TransferWise
+<p ><b><span >25.3 We may suspend your TransferWise
+Account for security reasons.</span></b><span >&nbsp;We may suspend your TransferWise
 Account or restrict its functionality if we have reasonable concerns about:</span></p>
 
-<p class=MsoNormal><span style='font-family:"Avenir W02",sans-serif;color:#5D7079;
-letter-spacing:.2pt'>(a) the security of your TransferWise Account; or</span></p>
+<p><span >(a) the security of your TransferWise Account; or</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>(b) suspected unauthorised or fraudulent use
+<p ><span >(b) suspected unauthorised or fraudulent use
 of your TransferWise Account.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>25.4 We will give you notice of
-suspension where possible.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;We will give you notice of any
+<p ><b><span >25.4 We will give you notice of
+suspension where possible.</span></b><span >&nbsp;We will give you notice of any
 suspension or restriction and the reasons for such suspension or restriction as
 soon as we can, either before the suspension or restriction is put in place, or
 immediately after, unless notifying you would be unlawful or compromise our
@@ -1369,21 +963,16 @@ reasonable security measures. We will lift the suspension and/or the
 restriction as soon as practicable after the reasons for the suspension and/or
 restriction have ceased to exist.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>25.5 You cannot use the App if this
-Agreement ends.&nbsp;</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>On termination for any reason all rights
+<p ><b><span >25.5 You cannot use the App if this
+Agreement ends.&nbsp;</span></b><span >On termination for any reason all rights
 granted to you in connection with the App shall cease, you must immediately
 delete or remove the App from your devices.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>26.
+<p ><b><span>26.
 Our right to make changes</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>26.1 We may change this Agreement by
-giving you at least two (2) months’ prior written notice.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If
+<p ><b><span >26.1 We may change this Agreement by
+giving you at least two (2) months’ prior written notice.</span></b><span>&nbsp;If
 we do this, you can terminate this Agreement immediately and free of charge at
 any time before the proposed date of the entry into force of the proposed
 changes, by providing written notice to us. If we do not hear from you during
@@ -1391,10 +980,8 @@ the notice period, you will be considered as having accepted the proposed
 changes and they will apply to you from the effective date specified on the
 notice.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>26.2 In some instances, we may change
-this Agreement immediately.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;Despite section 26.1, changes to this
+<p ><b><span >26.2 In some instances, we may change
+this Agreement immediately.</span></b><span >&nbsp;Despite section 26.1, changes to this
 Agreement which are (1) more favourable to you; (2) required by law; or (3)
 related to the addition of a new service, extra functionality to the existing
 Services; or (4) changes which neither reduce your rights nor increase your
@@ -1402,13 +989,10 @@ responsibilities, will come into effect immediately if they are stated in the
 change notice. Changes to exchange rates shall come into effect immediately
 without notice and you shall not have the right to object to such a change.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>27.
+<p ><b><span>27.
 How we may contact you</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>27.1 We usually contact you via email.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;For
+<p ><b><span >27.1 We usually contact you via email.</span></b><span>&nbsp;For
 this purpose, you must at all times maintain at least one valid email address
 in your TransferWise Account profile. You should check for incoming messages
 regularly and frequently, these emails may contain links to further
@@ -1421,33 +1005,23 @@ TransferWise Account, we will contact you via telephone, email, or both (unless
 contacting you would be unlawful or compromise our reasonable security
 measures).</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>27.2 Other ways we may contact you.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;In
+<p ><b><span >27.2 Other ways we may contact you.</span></b><span>&nbsp;In
 addition to communicating via email, we may contact you via letter or telephone
 where appropriate. If you use any mobile services, we may also communicate with
 you via SMS. Any communications or notices sent by:</span></p>
 
 <ol start=1 type=a>
- <li class=MsoNormal style='color:#5D7079'><b><span style='font-family:"Avenir W02",sans-serif;
-     color:#2E4369'>Email</span></b><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>&nbsp;will be deemed received by you on the same day
+ <li ><b><span >Email</span></b><span >&nbsp;will be deemed received by you on the same day
      if it is received in your email inbox before 5pm on a Business Day. If it
      is received in your email inbox after 5pm on a Business Day or at any
      other time, it will be deemed received on the next Business Day.</span></li>
- <li class=MsoNormal style='color:#5D7079'><b><span style='font-family:"Avenir W02",sans-serif;
-     color:#2E4369'>Post</span></b><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>&nbsp;will be deemed received three (3) days from the
+ <li ><b><span >Post</span></b><span >&nbsp;will be deemed received three (3) days from the
      date of posting for Belgian post or within five (5) days of posting for
      international post.</span></li>
- <li class=MsoNormal style='color:#5D7079'><b><span style='font-family:"Avenir W02",sans-serif;
-     color:#2E4369'>SMS</span></b><span style='font-family:"Avenir W02",sans-serif;
-     letter-spacing:.2pt'>&nbsp;will be deemed received the same day.</span></li>
+ <li ><b><span >SMS</span></b><span >&nbsp;will be deemed received the same day.</span></li>
 </ol>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>27.3</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Where
+<p ><b><span >27.3</span></b><span >&nbsp;Where
 legislation requires us to provide information to you on a durable medium, we will
 either send you an email (with or without attachment) or send you a
 notification pointing you to information on our Website in a way that enables
@@ -1455,50 +1029,34 @@ you to retain the information in print format or other format that can be
 retained by you permanently for future reference. Do keep copies of all
 communications we send or make available to you.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>27.4</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If you need a
+<p ><b><span >27.4</span></b><span >&nbsp;If you need a
 copy of the current Agreement or any other relevant document, please
-contact&nbsp;</span><a href="https://transferwise.com/contact"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>Customer Support</span></b></a><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>.</span></p>
+contact&nbsp;</span><a href="https://transferwise.com/contact"><b><span>Customer Support</span></b></a><span>.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>27.5 This Agreement is made in the
-English language.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;Documents or communications in any
+<p ><b><span >27.5 This Agreement is made in the
+English language.</span></b><span >&nbsp;Documents or communications in any
 other languages are for your convenience and only the English language version
 of them are official.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>28.
+<p ><b><span>28.
 Complaints</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>28.1</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If you have
+<p ><b><span >28.1</span></b><span >&nbsp;If you have
 any complaints about us or our Services, you may contact us following our&nbsp;</span><a
-href="https://transferwise.com/help-beta/article/2235393/customer-complaints-procedure"><b><span
-style='font-family:"Avenir W02",sans-serif;color:#00B9FF'>customer complaint
-procedure</span></b></a><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>.</span></p>
+href="https://transferwise.com/help-beta/article/2235393/customer-complaints-procedure"><b><span>customer complaint
+procedure</span></b></a><span >.</span></p>
 
-<p class=MsoNormal style='margin-top:24.0pt;line-height:24.0pt'><b><span
-style='font-size:21.0pt;font-family:"Avenir W02",sans-serif;color:#2E4369'>29.
+<p ><b><span>29.
 Other important terms</span></b></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>29.1 Nobody else has any rights under
-this Agreement.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;This Agreement is between you and us.
+<p ><b><span >29.1 Nobody else has any rights under
+this Agreement.</span></b><span >&nbsp;This Agreement is between you and us.
 No other person shall have any rights to enforce any of its terms. Neither of
 us will need to get the agreement of any other person in order to end or make
 any changes to this Agreement.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>29.2 We may transfer this Agreement to
-someone else.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;You may not transfer, assign,
+<p ><b><span >29.2 We may transfer this Agreement to
+someone else.</span></b><span >&nbsp;You may not transfer, assign,
 mortgage, charge, subcontract, declare a trust over or deal in any other manner
 with any or all of your rights and obligations under this Agreement (including
 the TransferWise Account) without our prior written consent. We reserve the
@@ -1507,40 +1065,28 @@ Account) or any right or obligation under this Agreement at any time without
 your consent and if permissible by law. This does not affect your rights to close
 your TransferWise Account under section 19.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>29.3 If a court finds part of this
-Agreement illegal, the rest will continue in force.</span></b><span
-style='font-family:"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;Each
+<p ><b><span >29.3 If a court finds part of this
+Agreement illegal, the rest will continue in force.</span></b><span>&nbsp;Each
 of the paragraphs of this Agreement operates separately. If any court or
 relevant authority decides that any of them are unlawful, the remaining
 paragraphs will remain in full force and effect.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>29.4 Even if we delay in enforcing this
-Agreement, we can still enforce it later.</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;If we delay in
+<p ><b><span >29.4 Even if we delay in enforcing this
+Agreement, we can still enforce it later.</span></b><span >&nbsp;If we delay in
 asking you to do certain things or in taking action, it will not prevent us
 taking steps against you at a later date.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>29.5 This Agreement supersedes any other
-previous agreements.</span></b><span style='font-family:"Avenir W02",sans-serif;
-color:#5D7079;letter-spacing:.2pt'>&nbsp;This Agreement supersedes and
+<p ><b><span >29.5 This Agreement supersedes any other
+previous agreements.</span></b><span >&nbsp;This Agreement supersedes and
 extinguishes all previous agreements between you and TransferWise, whether
 written or oral, relating to its subject matter.</span></p>
 
-<p class=MsoNormal style='margin-bottom:18.0pt'><b><span style='font-family:
-"Avenir W02",sans-serif;color:#2E4369'>29.6 Which laws apply to this Agreement
-and where you may bring legal proceedings.</span></b><span style='font-family:
-"Avenir W02",sans-serif;color:#5D7079;letter-spacing:.2pt'>&nbsp;This Agreement
+<p ><b><span >29.6 Which laws apply to this Agreement
+and where you may bring legal proceedings.</span></b><span >&nbsp;This Agreement
 is governed by Belgian law. Any dispute between you and us in connection with
 your TransferWise Account and/or this Agreement may be brought in the courts of
 Brussels, Belgium.</span></p>
 
-<p class=MsoNormal>&nbsp;</p>
+<p>&nbsp;</p>
 
 </div>
-
-</body>
-
-</html>


### PR DESCRIPTION
## Context

Our partner activo is consuming default.html as their T&Cs for TW and they will change after Brexit, needing a new one for EU based partners 

### Changes

Adding an updated eu.html T&Cs for European partners

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
